### PR TITLE
Use "certificato digitale" instead of "certificate SSL"

### DIFF
--- a/_projects/it/cie.md
+++ b/_projects/it/cie.md
@@ -5,7 +5,7 @@ logo: /assets/images/logo-cie@2x.png
 payoff: Carta d'Identità Elettronica
 description: >
   La nuova carta d'identità è molto più che un pezzo di plastica: puoi comunicarci via NFC, per usarla per varchi d'ingresso o come
-  certificato SSL d'identità.
+  certificato digitale d'identità (compatibile SSL).
 lang: it
 order: 9
 highlight: true


### PR DESCRIPTION
Il termine "Certificato SSL" è improprio. Userei "Certificato digitale" che ha una bella descrizione su Wikipedia oppure "Certificato X509 per operazioni digitali/online" che è tecnicamente più corretto.