### PR TITLE
Upgrade a jekyll 0.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
+   gem "jekyll-feed", "~> 0.9.2"
    gem 'jekyll-seo-tag'
    gem 'jekyll-redirect-from'
    gem 'jekyll-paginate'


### PR DESCRIPTION
La versione 0.9.2 di jekyll fissa un bug che consiste
nell'assenza di spazi tra il localname del tag entry e
l'attributo lang dello stesso (fixes #30)

