### PR TITLE
Change the link to the error tables

### DIFF
--- a/_projects/it/anpr.md
+++ b/_projects/it/anpr.md
@@ -26,7 +26,7 @@ Ad oggi, l'accesso ad ANPR è riservato solo agli operatori anagrafici e ai soft
 ### Documentazione
 Stiamo lavorando ad una revisione profonda della documentazione. Per ora, siamo riusciti a pubblicare in formato più facilmente consultabile tutte le tabelle e codici.
 
-[Tabelle e codici di errori](http://anpr.readthedocs.io/en/sphinx/)
+[Tabelle e codici di errori](https://italia.github.io/anpr/)
 
 
 ### Collaborazione


### PR DESCRIPTION
It'll take us a few more days to fix the layout of sphinx tables.
Point to the tables that work in the mean time.

This also brings consistency between what the github archive and developers.italia.it point to.