### PR TITLE
Added a new plugin (jekyll-tagging) to obtain post-lists per tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :jekyll_plugins do
    gem 'jekyll-redirect-from'
    gem 'jekyll-paginate'
    gem 'jekyll-toc'
+   gem 'jekyll-tagging'
    gem 'hawkins'
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,10 @@ exclude:
 paginate: 10
 paginate_path: "/news/page:num/"
 
+# tag pages
+tag_page_layout: posts_by_tag
+tag_page_dir: news
+
 # Custom vars
 theme_color: "#0066cc"
 css_theme: t-Pac

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -75,10 +75,10 @@
 
     </div>
 
-    {% if include.categories %}
+    {% if include.tags %}
     <div class="u-flex u-flexAlignItemsCenter u-flexAlignContentCenter u-margin-top-l">
       <p class="u-color-grey-50 u-margin-r-right">{{ t.news_categories }}</p>
-      {% include pills.html items=include.categories small=true %}
+      {% include pills.html items=include.tags small=true %}
     </div>
     {% endif %}
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -56,4 +56,4 @@
   <meta name="theme-color" content="{{ site.theme_color }}">
 
 </head>
-<body class="{{ site.css_theme }}">
+<body class="{{ site.css_theme }} layout-{{page.layout}}">

--- a/_includes/pills.html
+++ b/_includes/pills.html
@@ -1,7 +1,8 @@
 <ul>
   {% for item in include.items %}
+  {% assign default_url = '/news/' | append: item %}
   <li class="u-inlineBlock u-padding-r-right u-margin-r-bottom u-margin-r-top">
-    <a href="{{ item.link | default: item }}" class="Pill {% if include.small != true %}Pill--xs{% else %}Pill--xxs{% endif %}
+    <a href="{{ item.link | default: default_url }}" class="Pill {% if include.small != true %}Pill--xs{% else %}Pill--xxs{% endif %}
       u-background-50 u-color-white u-textClean u-textWeight-600 u-padding-bottom-xs">
         {{ item.title | default: item }} 
         <span class="Dot u-background-white u-margin-left-s u-alignMiddle"></span>

--- a/_includes/pills.html
+++ b/_includes/pills.html
@@ -1,9 +1,9 @@
 <ul>
   {% for item in include.items %}
   <li class="u-inlineBlock u-padding-r-right u-margin-r-bottom u-margin-r-top">
-    <a href="{{ item.link }}" class="Pill {% if include.small != true %}Pill--xs{% else %}Pill--xxs{% endif %}
+    <a href="{{ item.link | default: item }}" class="Pill {% if include.small != true %}Pill--xs{% else %}Pill--xxs{% endif %}
       u-background-50 u-color-white u-textClean u-textWeight-600 u-padding-bottom-xs">
-        {{ item.title | default: item }}
+        {{ item.title | default: item }} 
         <span class="Dot u-background-white u-margin-left-s u-alignMiddle"></span>
     </a>
   </li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
   {% assign subnav = site.data[page.subnav] %}
   {% include linklist.html items=subnav dynamic=true %}
   {% if site.disqus.shortname %} {% include disqus_comments.html %} {% endif %}
-  {% capture pills %}{% include pills.html items=page.categories  %}{% endcapture %}
+  {% capture pills %}{% include pills.html items=page.tags  %}{% endcapture %}
   {% include sideblock.html title=t.home_projects_expand content=pills %}
 {% endcomment %}
 
@@ -61,7 +61,7 @@ layout: default
 
         <div class="u-layoutCenter u-textCenter u-textSecondary u-margin-bottom-xxl">
           <h2 class="u-text-r-xxs u-textSecondary u-textWeight-300 u-margin-r-bottom">{{ t.news_categories }}</h2>
-          {% include pills.html items=page.categories small=true %}
+          {% include pills.html items=page.tags small=true %}
         </div>
 
       </div>

--- a/_layouts/posts_by_tag.html
+++ b/_layouts/posts_by_tag.html
@@ -33,7 +33,7 @@ lang: it
           link=post.url
           text=excerpt
           hasImage=false
-          categories=post.categories
+          categories=post.tags
           flat=true
           classes='u-background-grey-15'
           %}
@@ -45,7 +45,7 @@ lang: it
     </div>
 
     {% capture categories %}
-      {% for category in site.categories %}{{ category[0] }}:{% endfor %}
+      {% for category in site.tags %}{{ category[0] }}:{% endfor %}
     {% endcapture %}
 
     {% assign categories_ = categories | strip | split: ':' %}

--- a/_layouts/posts_by_tag.html
+++ b/_layouts/posts_by_tag.html
@@ -7,7 +7,11 @@ lang: it
 
 <div class="u-background-50 u-layout-r-withGutter u-padding-bottom-xxl u-padding-top-xxl">
   <h1 class="u-text-r-l u-textWeight-300 u-color-white u-margin-top-l u-lineHeight-l">
-    {{ t.news_title }}</h1>
+    {{ t.news_title }}
+    <span class="u-text-r-m u-color-20">&nbsp;/&nbsp;{{ page.tag }}</span>
+  </h1>
+  <h2 >
+    </h2>
 </div>
 
 <hr class="Separator-room reduced u-background-50" />
@@ -17,7 +21,7 @@ lang: it
   <div class="Grid">
 
     <div class="Grid-cell u-sizeFull u-md-size7of12 u-lg-size7of12">
-      {% for post in paginator.posts %}
+      {% for post in page.posts %}
 
         {% assign excerpt = post.excerpt | remove: '<p>' | remove: '</p>' '%}
 
@@ -37,20 +41,7 @@ lang: it
 
       {% endfor %}
 
-      <div>
-        {% if paginator.previous_page %}
-          <a href="{{ paginator.previous_page_path }}" class="u-color-50">{{ t.paginator_previous_page }}</a>
-        {% else %}
-          <span class="u-color-grey-20">{{ t.paginator_previous_page }}</span>
-        {% endif %}
-        <span>{{ t.paginator_page }}: {{ paginator.page }} {{ t.on_ }} {{ paginator.total_pages }}</span>
-        {% if paginator.next_page %}
-          <a href="{{ paginator.next_page_path }}" class="u-color-50">{{ t.paginator_next_page }}</a>
-        {% else %}
-          <span>{{ t.next_page }}</span>
-        {% endif %}
-      </div>
-
+      
     </div>
 
     {% capture categories %}

--- a/_plugins/ext.rb
+++ b/_plugins/ext.rb
@@ -1,0 +1,1 @@
+require 'jekyll/tagging'

--- a/_posts/it/2017-02-24-lancio.md
+++ b/_posts/it/2017-02-24-lancio.md
@@ -4,6 +4,7 @@ title:  Benvenuti in Developers Italia!
 subtitle: Apre in beta la community italiana degli sviluppatori dei servizi pubblici digitali
 date:   2017-02-24 11:00:00 +0100
 categories: eventi sviluppatori
+tags: eventi sviluppatori
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it

--- a/_posts/it/2017-02-24-lancio.md
+++ b/_posts/it/2017-02-24-lancio.md
@@ -3,11 +3,13 @@ layout: post
 title:  Benvenuti in Developers Italia!
 subtitle: Apre in beta la community italiana degli sviluppatori dei servizi pubblici digitali
 date:   2017-02-24 11:00:00 +0100
-categories: eventi sviluppatori
 tags: eventi sviluppatori
+categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it
+redirect_from:
+  - /eventi/sviluppatori/2017/02/24/lancio.html
 ---
 
 Developers Italia, creata in collaborazione tra [AgID](http://agid.gov.it) e il [Team per la Trasformazione Digitale](https://teamdigitale.governo.it), è la community italiana di sviluppatori di servizi pubblici, una piattaforma tecnologica dove ospitare tutti i principali progetti tecnologici di Paese che prevede:

--- a/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
+++ b/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
@@ -3,11 +3,13 @@ layout: post
 title:  Pubblicata la roadmap di SPID
 subtitle: Esce la prima roadmap di progetto di Developers Italia, per seguire il progetto e partecipare allo sviluppo
 date:   2017-05-25 17:00:00 +0100
-categories: roadmap progetti
 tags: roadmap progetti
+categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it
+redirect_from:
+  - /roadmap/progetti/2017/05/25/pubblicata-roadmap-spid.html
 ---
 
 Con molto piacere, questo è il link alla prima roadmap progettuale di Developers Italia: la [roadmap di SPID](https://trello.com/b/PHF0ErvK/spid-roadmap). La abbiamo preparata in forma di bacheca di Trello.

--- a/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
+++ b/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
@@ -4,6 +4,7 @@ title:  Pubblicata la roadmap di SPID
 subtitle: Esce la prima roadmap di progetto di Developers Italia, per seguire il progetto e partecipare allo sviluppo
 date:   2017-05-25 17:00:00 +0100
 categories: roadmap progetti
+tags: roadmap progetti
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it

--- a/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
+++ b/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
@@ -4,6 +4,7 @@ title:  Vuoi lavorare per Developers Italia?
 subtitle: Al via una serie di gare per sviluppare codice 100% open-source
 date:   2017-06-01 17:00:00 +0100
 categories: progetti sviluppatori
+tags: progetti sviluppatori
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it

--- a/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
+++ b/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
@@ -3,11 +3,13 @@ layout: post
 title:  Vuoi lavorare per Developers Italia?
 subtitle: Al via una serie di gare per sviluppare codice 100% open-source
 date:   2017-06-01 17:00:00 +0100
-categories: progetti sviluppatori
 tags: progetti sviluppatori
+categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it
+redirect_from:
+  - /progetti/sviluppatori/2017/06/01/vuoi-lavorare-developers-italia.html
 ---
 
 Vuoi lavorare per Developers Italia? Sei un'azienda specializzata in tecnologie e framework open source, e vuoi aiutare il tuo Paese a sviluppare servizi digitali innovativi? Allora stiamo cercando proprio te!

--- a/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
+++ b/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
@@ -4,6 +4,7 @@ title:  Nasce Hack.Developers, il più grande code sprint mai realizzato in Ital
 subtitle: Il 7 e 8 Ottobre, partecipa in più di 20 sedi nel territorio per costruire una PA a misura di cittadino
 date:   2017-07-27 17:00:00 +0100
 categories: hackathon eventi sviluppatori
+tags: hackathon eventi sviluppatori
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it

--- a/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
+++ b/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
@@ -3,11 +3,13 @@ layout: post
 title:  Nasce Hack.Developers, il più grande code sprint mai realizzato in Italia
 subtitle: Il 7 e 8 Ottobre, partecipa in più di 20 sedi nel territorio per costruire una PA a misura di cittadino
 date:   2017-07-27 17:00:00 +0100
-categories: hackathon eventi sviluppatori
 tags: hackathon eventi sviluppatori
+categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it
+redirect_from:
+  - /hackathon/eventi/sviluppatori/2017/07/27/hack-developers-hackathon-per-pubblica-amministrazione.html
 ---
 
 Probabilmente sarete pronti a partire per le vacanze, ma prima segnate in agenda le date del **7 e 8 ottobre 2017** perché il [Team per la Trasformazione Digitale](https://teamdigitale.governo.it/), in collaborazione con [Codemotion](https://codemotionworld.com/), organizza [Hack Developers Italia](https://hack.developers.italia.it), il più grande code sprint mai realizzato in Italia.

--- a/_posts/it/2017-09-07-hack-developers-meetup.md
+++ b/_posts/it/2017-09-07-hack-developers-meetup.md
@@ -4,6 +4,7 @@ title:  Meetup su Hack.Developers, incontraci dall'11 al 19 Settembre
 subtitle: 6 incontri a giro per l'Italia, incontrando gli sviluppatori prima di Hack.Developers
 date:   2017-09-07 17:00:00 +0100
 categories: hackathon eventi sviluppatori
+tags: hackathon eventi sviluppatori
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it

--- a/_posts/it/2017-09-07-hack-developers-meetup.md
+++ b/_posts/it/2017-09-07-hack-developers-meetup.md
@@ -3,11 +3,13 @@ layout: post
 title:  Meetup su Hack.Developers, incontraci dall'11 al 19 Settembre
 subtitle: 6 incontri a giro per l'Italia, incontrando gli sviluppatori prima di Hack.Developers
 date:   2017-09-07 17:00:00 +0100
-categories: hackathon eventi sviluppatori
 tags: hackathon eventi sviluppatori
+categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
 lang: it
+redirect_from:
+  - /hackathon/eventi/sviluppatori/2017/09/07/hack-developers-meetup.html
 ---
 Ciao a tutti,
  

--- a/_sass/_developer.scss
+++ b/_sass/_developer.scss
@@ -458,6 +458,10 @@
   outline: 3px solid #06c;
 }
 
+.Separator-room.reduced {
+  padding-bottom: 2rem;
+}
+
 @media screen and (max-width: 767px) {
 
   .u-minHeight-250 {
@@ -473,3 +477,5 @@
   }
 
 }
+
+

--- a/news/index.html
+++ b/news/index.html
@@ -29,7 +29,7 @@ lang: it
           link=post.url
           text=excerpt
           hasImage=false
-          categories=post.categories
+          categories=post.tags
           flat=true
           classes='u-background-grey-15'
           %}
@@ -54,7 +54,7 @@ lang: it
     </div>
 
     {% capture categories %}
-      {% for category in site.categories %}{{ category[0] }}:{% endfor %}
+      {% for category in site.tags %}{{ category[0] }}:{% endfor %}
     {% endcapture %}
 
     {% assign categories_ = categories | strip | split: ':' %}


### PR DESCRIPTION
Attenzione, il plugin jekyll-tagging si aspetta nel frontmatter "tags" piuttosto che "categories" come attualmente utilizzato. Dobbiamo quindi decidere se eliminare "categories" in favore dello standard tags oppure fare override del plugin.
Al momento nel FM dei posts ci sono sia categories sia tags, con valori uguali.
@rasky 