### PR TITLE
Footer typofix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,7 +72,7 @@ owner_link: http://www.agid.gov.it
 logo: /assets/icons/logo-it.png
 owner_logo: https://www.spid.gov.it/assets/img/agid-logo-bb.svg
 partner_short: Team Digitale
-partner_full: Team Digitale
+partner_full: Team per la Trasformazione Digitale
 partner_link: https://teamdigitale.governo.it
 privacy_link: https://developers.italia.it/it/privacy-policy
 gov_logo: https://teamdigitale.governo.it/images/loghi/governo.svg

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
             {{ site.partner_short }}
           </span>
           <span class="u-hidden u-md-inline u-lg-inline u-sm-inline">
-            {{ site.partner_full }}
+            {{ site.partner_short }}
           </span>
         </a>
     </div>


### PR DESCRIPTION
Typo fix for the name of  the Digital Team. Now "full" on the footer and always "short" on the slimheader