### PR TITLE
Upgrade to jekyll 3.6.0 and ruby 2.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.5.2"
+gem "jekyll", "3.6.0"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,16 +37,16 @@ GEM
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     i18n (0.8.6)
-    jekyll (3.5.2)
+    jekyll (3.6.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
-      kramdown (~> 1.3)
+      kramdown (~> 1.14)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (~> 1.7)
+      rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
@@ -65,7 +65,7 @@ GEM
       nokogiri (~> 1.6)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.14.0)
+    kramdown (1.15.0)
     liquid (4.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -93,7 +93,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (1.11.1)
+    rouge (2.2.1)
     safe_yaml (1.0.4)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
@@ -116,7 +116,7 @@ PLATFORMS
 DEPENDENCIES
   hawkins
   html-proofer
-  jekyll (= 3.5.2)
+  jekyll (= 3.6.0)
   jekyll-feed (~> 0.9.2)
   jekyll-paginate
   jekyll-redirect-from
@@ -128,6 +128,9 @@ DEPENDENCIES
   parallel
   rest-client (~> 2.0)
   tzinfo-data
+
+RUBY VERSION
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.15.4


### PR DESCRIPTION
This commit upgrades our website to jekyll 3.6.0. Full changelog at https://jekyllrb.com/docs/history/

I've also upgraded our ruby stack to 2.4.2 - no problems reported.