### PR TITLE
fix: Corretti link guida 18app

### DIFF
--- a/_projects/it/18app.md
+++ b/_projects/it/18app.md
@@ -52,8 +52,6 @@ Qui potete trovare la documentazione tecnica di accesso alle API per gli esercen
 che si devono integrare con la piattaforma, e il mockup della nuova mobile app
 il cui sviluppo deve ancora cominciare.
 
-[Documentazione su ReadTheDocs](http://18app.readthedocs.io/it/latest)
-
 [Documentazione dei webservice per esercenti](http://guida-18app.readthedocs.io/it/latest/)
 
 [Mockup della mobile app nativa](https://invis.io/RSDORU6E2)

--- a/_projects/it/18app.md
+++ b/_projects/it/18app.md
@@ -52,9 +52,9 @@ Qui potete trovare la documentazione tecnica di accesso alle API per gli esercen
 che si devono integrare con la piattaforma, e il mockup della nuova mobile app
 il cui sviluppo deve ancora cominciare.
 
-[Documentazione su ReadTheDocs](http://18app.readthedocs.io/en/latest/index.html)
+[Documentazione su ReadTheDocs](http://18app.readthedocs.io/it/latest)
 
-[Documentazione dei webservice per esercenti](https://github.com/italia/18app-merchant-sdk/issues/1)
+[Documentazione dei webservice per esercenti](http://guida-18app.readthedocs.io/it/latest/)
 
 [Mockup della mobile app nativa](https://invis.io/RSDORU6E2)
 


### PR DESCRIPTION
I link nella versione originale erano errati.

Rimosso il primo link che puntava alla versione di prova, ormai obsoleta. L'unica guida rilevante al momento è quella per gli esercenti.