### PR TITLE
Crea news su consultazione per lg software

### DIFF
--- a/_posts/it/2018-04-16-linee-guida-su-acquisizione-e-riuso-del-software.md
+++ b/_posts/it/2018-04-16-linee-guida-su-acquisizione-e-riuso-del-software.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title:  Linee guida sull’acquisizione e il riuso del software, aperta la consultazione
+subtitle: La consultazione aperta dal 5 aprile al 5 maggio 2018
+date:   2018-04-16 10:00:00 +0100
+tags: developers software opensource
+categories: news
+author: Francesco De Augustinis
+image: /assets/icons/logo-it.svg
+lang: it
+redirect_from:
+   - 
+---
+
+Dal **5 aprile al 5 maggio** su [Docs Italia](https://docs.developers.italia.it/) è possibile partecipare ad una consultazione pubblica sulle nuove “[Linee guida sull’acquisizione e il riuso di software per le pubbliche amministrazioni](http://lg-acquisizione-e-riuso-software-per-la-pa.readthedocs.io/it/latest/)”. 
+
+Il testo stabilisce regole e modalità di **acquisizione** e di **condivisione** del software tra tutti i soggetti pubblici. La consultazione è aperta a tutti, in particolare **i fornitori e le pubbliche amministrazioni**. 
+
+## Le nuove linee guida sul software, di che si tratta
+
+Le “[Linee guida sull’acquisizione e il riuso di software per le pubbliche amministrazioni](http://lg-acquisizione-e-riuso-software-per-la-pa.readthedocs.io/it/latest/)” sono espressamente previste dal [Codice dell’amministrazione digitale](https://cad.readthedocs.io/it/v2017-12-13/_rst/capo6.html) (CAD). Servono per:
+
+* Definire in che modo una pubblica amministrazione deve effettuare la **valutazione comparativa** obbligatoria per acquisire un software, preferendo il software open source all’acquisizione di software tramite licenza.
+
+* Indicare in che modo le pubbliche amministrazioni possono condividere e riutilizzare il software sotto licenza aperta e i requisiti che le piattaforme per la pubblicazione e la condivisione (come [GitHub](https://github.com/) e [GitLab](https://about.gitlab.com/)) devono avere.
+
+## Partecipa alla consultazione!
+
+Puoi prendere parte alla consultazione direttamente su [Docs Italia](http://lg-acquisizione-e-riuso-software-per-la-pa.readthedocs.io/it/latest/), cliccando l’apposito link in fondo ad ogni sezione delle linee guida ed aprendo la discussione. Tutti i contributi saranno presi in considerazione dall’[Agenzia per l’Italia Digitale](http://www.agid.gov.it/) e dal [Team per la trasformazione digitale](https://teamdigitale.governo.it/) per la redazione del testo definitivo.
+
+**Approfondisci**: [Istruzioni per la consultazione pubblica su DocsItalia](http://test-acquisizione-riuso.readthedocs.io/it/latest/istruzioni-per-la-consultazione-pubblica.html)
+
+[Partecipa subito alla consultazione!](http://lg-acquisizione-e-riuso-software-per-la-pa.readthedocs.io/it/latest/)
+
+A presto!
+
+Il team di Developers Italia


### PR DESCRIPTION
Crea news per l'apertura della consultazione sulle "Linee guida sull’acquisizione e il riuso del software" fino al 5 maggio 2018 