### PR TITLE
Bugfix: news in home page were not filtered by active language

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 {% include setlang.html %}
-{% assign news = site.posts | sort: 'date' | reverse | first %}
+{% assign news = site.posts | where: 'locale', active_lang | sort: 'date' | reverse | first %}
 
 
 <section class="homelayout__first">

--- a/_posts/en/2018-05-23-un-ambiente-di-test-aperto-a-tutti-per-anpr.md
+++ b/_posts/en/2018-05-23-un-ambiente-di-test-aperto-a-tutti-per-anpr.md
@@ -8,7 +8,7 @@ tags: developers opensource anpr
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: en_US
+locale: en
 redirect_from:
    - 
 ---

--- a/_posts/en/2019-03-06-developers-italia-al-google-summer-of-code-2019.md
+++ b/_posts/en/2019-03-06-developers-italia-al-google-summer-of-code-2019.md
@@ -7,7 +7,7 @@ tags: developers daf api designers gsoc
 categories: news
 author: Leonardo Favario
 image: /assets/icons/logo-it.svg
-locale: en_US
+locale: en
 redirect_from:
    -
 ---

--- a/_posts/it/2017-02-24-lancio.md
+++ b/_posts/it/2017-02-24-lancio.md
@@ -7,7 +7,7 @@ tags: eventi sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - /eventi/sviluppatori/2017/02/24/lancio.html
 ---

--- a/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
+++ b/_posts/it/2017-05-25-pubblicata-roadmap-spid.md
@@ -7,7 +7,7 @@ tags: roadmap progetti
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - /roadmap/progetti/2017/05/25/pubblicata-roadmap-spid.html
 ---

--- a/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
+++ b/_posts/it/2017-06-01-vuoi-lavorare-developers-italia.md
@@ -7,7 +7,7 @@ tags: progetti sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - /progetti/sviluppatori/2017/06/01/vuoi-lavorare-developers-italia.html
 ---

--- a/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
+++ b/_posts/it/2017-07-27-hack-developers-hackathon-per-pubblica-amministrazione.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - /hackathon/eventi/sviluppatori/2017/07/27/hack-developers-hackathon-per-pubblica-amministrazione.html
 ---

--- a/_posts/it/2017-09-07-hack-developers-meetup.md
+++ b/_posts/it/2017-09-07-hack-developers-meetup.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - /hackathon/eventi/sviluppatori/2017/09/07/hack-developers-meetup.html
 ---

--- a/_posts/it/2017-10-03-hack-developers-ti-aspettiamo.md
+++ b/_posts/it/2017-10-03-hack-developers-ti-aspettiamo.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Team Developers Italia
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - 
 ---

--- a/_posts/it/2017-10-11-hack-developers-come-e-andata.md
+++ b/_posts/it/2017-10-11-hack-developers-come-e-andata.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Team Developers Italia
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
   - 
 ---

--- a/_posts/it/2017-10-23-hack-developers-ecco-i-vincitori-fast-rabbit.md
+++ b/_posts/it/2017-10-23-hack-developers-ecco-i-vincitori-fast-rabbit.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    - 
 ---

--- a/_posts/it/2017-11-08-hack-developers-tutti-i-progetti-vincitori-del-code-sprint.md
+++ b/_posts/it/2017-11-08-hack-developers-tutti-i-progetti-vincitori-del-code-sprint.md
@@ -7,7 +7,7 @@ tags: hackathon eventi sviluppatori
 categories: news
 author: Giovanni Bajo
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    - 
 ---

--- a/_posts/it/2018-02-21-developers-italia-al-google-summer-or-code.md
+++ b/_posts/it/2018-02-21-developers-italia-al-google-summer-or-code.md
@@ -7,7 +7,7 @@ tags: developers daf gsoc
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    -
 ---

--- a/_posts/it/2018-03-07-ti-presentiamo-il-nuovo-docs-italia.md
+++ b/_posts/it/2018-03-07-ti-presentiamo-il-nuovo-docs-italia.md
@@ -7,7 +7,7 @@ tags: developers docsitalia
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    -
 ---

--- a/_posts/it/2018-03-12-code-hands-on-laboratori-aperti-per-la-milano-digital-week.md
+++ b/_posts/it/2018-03-12-code-hands-on-laboratori-aperti-per-la-milano-digital-week.md
@@ -7,7 +7,7 @@ tags: developers digitalweek
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    - 
 ---

--- a/_posts/it/2018-04-05-linee-guida-in-consultazione.md
+++ b/_posts/it/2018-04-05-linee-guida-in-consultazione.md
@@ -7,7 +7,7 @@ tags: developers daf gsoc
 categories: news
 author: Riccardo Iaconelli
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    -
 ---

--- a/_posts/it/2018-04-16-linee-guida-su-acquisizione-e-riuso-del-software.md
+++ b/_posts/it/2018-04-16-linee-guida-su-acquisizione-e-riuso-del-software.md
@@ -7,7 +7,7 @@ tags: developers software opensource
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    -
 ---

--- a/_posts/it/2018-05-16-un-webinar-per-le-software-house-sull-acquisizione-e-il-riuso-del-software.md
+++ b/_posts/it/2018-05-16-un-webinar-per-le-software-house-sull-acquisizione-e-il-riuso-del-software.md
@@ -7,7 +7,7 @@ tags: developers software opensource
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    - 
 ---

--- a/_posts/it/2018-05-23-un-ambiente-di-test-aperto-a-tutti-per-anpr.md
+++ b/_posts/it/2018-05-23-un-ambiente-di-test-aperto-a-tutti-per-anpr.md
@@ -8,7 +8,7 @@ tags: developers open-source anpr
 categories: news
 author: Francesco De Augustinis
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    - 
 ---

--- a/_posts/it/2019-03-06-developers-italia-al-google-summer-of-code-2019.md
+++ b/_posts/it/2019-03-06-developers-italia-al-google-summer-of-code-2019.md
@@ -7,7 +7,7 @@ tags: developers daf gsoc
 categories: news
 author: Leonardo Favario
 image: /assets/icons/logo-it.svg
-locale: it_IT
+locale: it
 redirect_from:
    -
 ---

--- a/en/news/index.html
+++ b/en/news/index.html
@@ -5,7 +5,7 @@ title: News
 pagination:
   enabled: true
   permalink: '/en/news/page:num'
-  locale: en_US
+  locale: en
 ---
 
 {% include setlang.html %}

--- a/it/news/index.html
+++ b/it/news/index.html
@@ -5,8 +5,7 @@ title: News
 pagination:
   enabled: true
   permalink: '/it/news/page:num'
-  locale: it_IT
+  locale: it
 ---
 
 {% include setlang.html %}
-


### PR DESCRIPTION
Front news in home page it currently displayed in a random language because no filter is applied.

This PR fixes the issue. I changed the `locale` values from `it_IT` to `it` because it is allowed by the jekyll-paginate-v2 plugin, so that we can match that field against the `active_lang` variable.