### PR TITLE
Switch DAF API to coming soon

### DIFF
--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -15,6 +15,7 @@
     logo: https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/external-apis/img/api.daf.teamdigitale.it.png
   tags: []
   language: [it]
+  comingsoon: true
   slug: daf-ckan
 - openapi: https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/external-apis/siopeplus.yaml
   title: SIOPE+


### PR DESCRIPTION
Since there is no fix available yet, I propose switching the [API page](https://developers.italia.it/it/api/daf-ckan) to coming soon in order not to display an error in the page. 
If not, do you have an idea about what's needed to fix it? @ioggstream @jenkin 
See https://github.com/italia/developers.italia.it/issues/359 for further details.