### PR TITLE
Switch logo to SVG.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,7 +86,7 @@ css_theme: t-Pac
 owner_short: AgID
 owner_full: AgID
 owner_link: http://www.agid.gov.it
-logo: /assets/icons/logo-it.png
+logo: /assets/icons/logo-it.svg
 owner_logo: /assets/images/agid-logo-bb.svg
 partner_short: Team Digitale
 partner_full: Team per la Trasformazione Digitale


### PR DESCRIPTION
This PR switches the logo from the previous PNG one to the SVG icon. 
Fix #339 .
The new logo is slightly bigger but I think it's OK. 
@sebbalex 