### PR TITLE
Allow to configure the data key to use for page title

### DIFF
--- a/_plugins/data_page_generator.rb
+++ b/_plugins/data_page_generator.rb
@@ -28,10 +28,11 @@ module Jekyll
     # - `dir` is the default output directory
     # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
     # - `name` is the key in `data` which determines the output filename
+    # - `title` is the key in `data` which determines the output title (if none, the one pointed by `name` will be used)
     # - `template` is the name of the template for generating the page
     # - `extension` is the extension for the generated file
     # - `defaults` is an object with additional data values
-    def initialize(site, base, index_files, dir, data, name, template, extension, defaults = {})
+    def initialize(site, base, index_files, dir, data, name, title, template, extension, defaults = {})
       @site = site
       @base = base
 
@@ -54,7 +55,9 @@ module Jekyll
         # original method to set page title to data[name]
         # self.data['title'] = data[name]
 
-        if data['publiccode'] && data['publiccode']['name']
+        if title
+          self.data['title'] = data[title]
+        elsif data['publiccode'] && data['publiccode']['name']
           self.data['title'] = data['publiccode']['name'] + ' - ' + defaults['title_suffix']
         else
           self.data['title'] = data[name]
@@ -89,6 +92,7 @@ module Jekyll
           index_files_for_this_data = data_spec['index_files'] != nil ? data_spec['index_files'] : index_files
           template = data_spec['template'] || data_spec['data']
           name = data_spec['name']
+          title = data_spec['title']
           dir = data_spec['dir'] || data_spec['data']
           extension = data_spec['extension'] || "html"
 
@@ -111,7 +115,7 @@ module Jekyll
             records = records.select { |record| eval(data_spec['filter_condition']) } if data_spec['filter_condition']
 
             records.each do |record|
-              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, template, extension, data_spec['defaults'])
+              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, title, template, extension, data_spec['defaults'])
             end
           else
             puts "error (datapage_gen). could not find template #{template}" if not site.layouts.key? template


### PR DESCRIPTION
With this PR, we can configure distinct data keys to use for page title and page name (filename). In case of public administrations, we want to use the iPA code as filename and their full name as page title:

```yaml
 - index_files: false
    name: ipa
    title: entityName
    data: crawler.amministrazioni
    template: brand-pa
    defaults:
      lang: it
    dir: it/pa
```