### PR TITLE
Add missing import for daf swagger ui

### DIFF
--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -15,7 +15,7 @@
     logo: https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/external-apis/img/api.daf.teamdigitale.it.png
   tags: []
   language: [it]
-  comingsoon: true
+  comingsoon: false 
   slug: daf-ckan
 - openapi: https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/external-apis/siopeplus.yaml
   title: SIOPE+

--- a/swagger/components/Hero.js
+++ b/swagger/components/Hero.js
@@ -23,7 +23,7 @@ class Hero extends Component {
     */
     const projects = require("../projects.js");
     const { specSelectors, getComponent } = this.props;
-      
+
     const info = specSelectors.info();
     const title = info.get("title");
     const version = info.get("version");

--- a/swagger/components/Hero.js
+++ b/swagger/components/Hero.js
@@ -18,8 +18,9 @@ const copyToClipboard = text => {
 
 class Hero extends Component {
   render() {
+    const projects = require("../projects.js");
     const { specSelectors, getComponent } = this.props;
-
+      
     const info = specSelectors.info();
     const title = info.get("title");
     const version = info.get("version");
@@ -34,6 +35,7 @@ class Hero extends Component {
     const summary = info.get("x-summary");
     const project = info.get("x-project");
 
+    // Check if project exists in the projects list.
     const reference = projects.filter(proj => proj.id === project)[0];
 
     const {


### PR DESCRIPTION
This PR:

- adds an import of `projects.js` in order to correctly render the DAF API page. In such a way, the project is correctly located and processed and the react error is avoided. 

See #359 for further details. 
@ioggstream 

