### PR TITLE
Add pagopa's ios and android sdk (#404)

### DIFF
--- a/_platforms/en/pagopa.md
+++ b/_platforms/en/pagopa.md
@@ -71,6 +71,15 @@ resources:
         icon: github
         url: https://github.com/italia/pagopa-soap-ruby
         desc: Ruby library for accessing the SOAP API
+      - title: SDK for iOS
+        icon: github
+        url: https://github.com/italia/pagopa-ios-sdk
+        desc: Native library for accessing the SOAP API in iOS applications
+      - title: SDK for Android
+        icon: github
+        url: https://github.com/italia/pagopa-android-sdk
+        desc: Native library for accessing the SOAP API in Android (Java) applications
+
 ---
 
 ## Intro

--- a/_platforms/it/pagopa.md
+++ b/_platforms/it/pagopa.md
@@ -69,6 +69,14 @@ resources:
         icon: github
         url: https://github.com/italia/pagopa-soap-ruby
         desc: Libreria Ruby per accesso alle API SOAP
+      - title: SDK per iOS
+        icon: github
+        url: https://github.com/italia/pagopa-ios-sdk
+        desc: Libreria nativa per accesso alle API SOAP in applicazioni mobile iOS
+      - title: SDK per Android
+        icon: github
+        url: https://github.com/italia/pagopa-android-sdk
+        desc: Libreria nativa per accesso alle API SOAP in applicazioni mobile Android
 
 ---
 


### PR DESCRIPTION
Hi, I only added pagopa-ios-sdk and pagopa-android-sdk to the pagoPA page, as requested in issue #404.

