### PR TITLE
Issue #330: remove href when url is missing

### DIFF
--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -74,7 +74,10 @@ layout: default
               <p><span class="label">{{ t.software.technical_contact }} </span>
                 {% for contact in page.publiccode.maintenance.contacts limit: 1 %}
                     {% if contact.email != nil and contact.email != "" %}
-                    <a href="mailto:{{ contact.email }}">{{ contact.name }}</a>
+                    <a href="mailto:{{ contact.email }}">
+                      <span class="icon it-mail d-inline-block"></span>
+                      {{ contact.name }}
+                    </a>
                     {% else %}
                     {{ contact.name }}
                     {% endif %}
@@ -251,8 +254,8 @@ layout: default
             | default: variant.publiccode.description.en
             | default: variant.publiccode.description.it %}
             <div class="variantDetail">
-              <a href="/{{active_lang}}/software/{{ variant.slug | downcase }}"> 
-              {{ variant.publiccode.name }} 
+              <a href="/{{active_lang}}/software/{{ variant.slug | downcase }}">
+              {{ variant.publiccode.name }}
               </a>
               {{ t.software.variant_by }} {{ variant.publiccode.legal.repoOwner }}
               <!--
@@ -388,8 +391,15 @@ layout: default
                 <p>
                   <span class="label">{{ t.software.contract_with }}</span>
                   {% for contractor in page.publiccode.maintenance.contractors %}
-                  <a href="{{ contractor.website }}" class="until">{{ contractor.name }}</a> {{ t.software.until }} {{
-                  contractor.until}}
+                    {% if contractor.website %}
+                    <a href="{{ contractor.website }}" class="until">
+                      <span class="icon it-external-link d-inline-block"></span>
+                      {{ contractor.name }}
+                    </a>
+                    {{ t.software.until }} {{contractor.until}}
+                    {% else %}
+                    {{ contractor.name }} {{ t.software.until }} {{contractor.until}}
+                    {% endif %}
                   {% endfor %}
                 </p>
               </div>
@@ -425,7 +435,7 @@ layout: default
                 <div class="col-md">
                   <p>
                     {% if contact.email != nil and contact.email != "" %}
-                    <a href="mailto:{{ contact.email }}">{{ contact.name }}</a> 
+                    <a href="mailto:{{ contact.email }}">{{ contact.name }}</a>
                     {% else %}
                     {{ contact.name }}
                     {% endif %}

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -74,10 +74,7 @@ layout: default
               <p><span class="label">{{ t.software.technical_contact }} </span>
                 {% for contact in page.publiccode.maintenance.contacts limit: 1 %}
                     {% if contact.email != nil and contact.email != "" %}
-                    <a href="mailto:{{ contact.email }}">
-                      <span class="icon it-mail d-inline-block"></span>
-                      {{ contact.name }}
-                    </a>
+                    <a href="mailto:{{ contact.email }}">{{ contact.name }}</a>
                     {% else %}
                     {{ contact.name }}
                     {% endif %}
@@ -391,7 +388,7 @@ layout: default
                 <p>
                   <span class="label">{{ t.software.contract_with }}</span>
                   {% for contractor in page.publiccode.maintenance.contractors %}
-                    {% if contractor.website %}
+                    {% if contractor.website != nil and contractor.website != "" %}
                     <a href="{{ contractor.website }}" class="until">
                       <span class="icon it-external-link d-inline-block"></span>
                       {{ contractor.name }}

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -389,11 +389,8 @@ layout: default
                   <span class="label">{{ t.software.contract_with }}</span>
                   {% for contractor in page.publiccode.maintenance.contractors %}
                     {% if contractor.website != nil and contractor.website != "" %}
-                    <a href="{{ contractor.website }}" class="until">
-                      <span class="icon it-external-link d-inline-block"></span>
-                      {{ contractor.name }}
-                    </a>
-                    {{ t.software.until }} {{contractor.until}}
+                    <a href="{{ contractor.website }}" class="until">{{ contractor.name }}</a> {{ t.software.until }} {{
+                    contractor.until}}
                     {% else %}
                     {{ contractor.name }} {{ t.software.until }} {{contractor.until}}
                     {% endif %}


### PR DESCRIPTION
- Remove href when `contractors.website` is not defined
- Add external link icon when `contractors.website` is defined
- Add email icon when `contact.email` is defined

See https://github.com/italia/developers.italia.it/issues/330.

Please note that I wasn't able to reproduce the situation where `website` key is missing from a contractors. I'm pretty sure the fix should work fine but please double check. (or tell me how can I do the check). Thanks