### PR TITLE
Fix the wording: photos->images

### DIFF
--- a/_data/l10n.yml
+++ b/_data/l10n.yml
@@ -189,7 +189,7 @@ it:
       software_type: tipologia software
       public_entities: Enti
       go_to_detail: vai al dettaglio
-      view_all_photos: Guarda tutte le foto
+      view_all_photos: Guarda tutte le immagini
       tooltip: "
         [Vitality è un indice](https://docs.italia.it/italia/developers-italia/lg-acquisizione-e-riuso-software-per-pa-docs/it/stabile/acquisizione-software/macro-fase-2-analisi-delle-soluzioni-a-riuso-delle-pa-e-delle-soluzioni-open-source.html#fase-2-2-valutazione-soluzioni-riusabili-per-la-pa) calcolato prendendo in considerazione le seguenti quattro categorie:
 
@@ -394,7 +394,7 @@ en:
       software_type: software type
       public_entities: public entities
       go_to_detail: go to detail
-      view_all_photos: View all the photos
+      view_all_photos: View all the images
       tooltip: "
         [Vitality is an index](https://lg-acquisizione-e-riuso-software-per-la-pa.readthedocs.io/it/latest/acquisizione-software/macro-fase-2-analisi-delle-soluzioni-a-riuso-delle-pa-e-delle-soluzioni-open-source.html#fase-2-2-valutazione-soluzioni-riusabili-per-la-pa) calculated following the four main categories of the document:
 


### PR DESCRIPTION
The website references listed screenshots as "photos". I think it sounds very weird, especially in Italian: a software has no "photos".

While "screenshot" is probably too technical, I feel "images" is a good compromise, hence I propose this change.