### PR TITLE
Remove newsletter forms

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,6 +22,7 @@ layout: default
             <h1>{{news.title}}</h1>
             <a href="{{news.url}}" title="{{news.title}}">{{t.software.read_more}} &rarr;</a>
           </div>
+          <!--
           <div class="homelayout__first__newsletter mt-2 mt-md-5">
             <h2 class="mt-5 mt-md-3">Newsletter</h2>
             <form action="{{newsletterdata.action}}" method="post" target="_blank">
@@ -46,6 +47,7 @@ layout: default
               </div>
             </form>
           </div>
+          -->
         </div>
 
       </article>

--- a/_layouts/platform.html
+++ b/_layouts/platform.html
@@ -72,9 +72,11 @@ Still to-do:
       {% include platform-resources.html %}
       {% endif %}
 
+      {% comment %}
       {% if page.newsletterdata %}
       {% include banner-newsletter.html newsletterdata=page.newsletterdata %}
       {% endif %}
+      {% endcomment %}
     </div>
 
     {% capture toc %}
@@ -84,11 +86,13 @@ Still to-do:
       <li class="toc-entry toc-h2"><a href="#resources">{{ page.resources | objects_keys | join: ", " }}</a></li>
     </ul>
     {% endif %}
+    {% comment %}
     {% if page.newsletterdata %}
     <ul class="section-nav">
       <li class="toc-entry toc-h2"><a href="#newsletter">Newsletter</a></li>
     </ul>
     {% endif %}
+    {% endcomment %}
     {% endcapture %}
     {% include sideblock.html image=page.logo content=toc %}
 

--- a/_pages/en/contacts.md
+++ b/_pages/en/contacts.md
@@ -7,7 +7,7 @@ ref:
 layout: internal-simple
 image: /assets/images/chisiamo-img.jpg
 redirect_from: /en/who-we-are
-include-developers-newsletter: true
+include-developers-newsletter: false
 pair-blocks:
     - title: "Work with us"
       text: "You may find the open positions (when they are available) in the

--- a/_pages/it/contatti.md
+++ b/_pages/it/contatti.md
@@ -7,7 +7,7 @@ ref:
 layout: internal-simple
 image: /assets/images/chisiamo-img.jpg
 redirect_from: /it/chi-siamo
-include-developers-newsletter: true
+include-developers-newsletter: false
 pair-blocks:
     - title: "Lavora con noi"
       text: "Puoi trovare tutte le eventuali posizioni aperte nella sezione [Lavora con noi](https://teamdigitale.governo.it/it/36-content.htm) del Team per la Trasformazione Digitale."

--- a/_platforms/en/anpr.md
+++ b/_platforms/en/anpr.md
@@ -67,7 +67,7 @@ resources:
 
 ## Intro
 
-**Do you want to stay up-to-date? Subscribe to the ANPR [newsletter](#newsletter).**
+<!-- **Do you want to stay up-to-date? Subscribe to the ANPR [newsletter](#newsletter).** -->
 
 ANPR is a memorable project: instead of having more than 8,000 registries spread over the entire
 national territory (in evey municipality), Italy will have finally a single centralised registry

--- a/_platforms/it/anpr.md
+++ b/_platforms/it/anpr.md
@@ -65,7 +65,7 @@ resources:
 
 ## Intro
 
-**Vuoi avere aggiornamenti su ANPR? Iscriviti alla [newsletter di ANPR](#newsletter).**
+<!-- **Vuoi avere aggiornamenti su ANPR? Iscriviti alla [newsletter di ANPR](#newsletter).** -->
 
 [ANPR](https://anpr.interno.it/) è un progetto storico: invece di avere più di 8.000 anagrafi dislocate nel territorio (in ciascun comune), l'Italia avrà finalmente una anagrafe centrale unica, che semplificherà tutti gli adempimenti.
 In futuro speriamo di potervi dare funzionalità come poter comunicare una variazione di domicilio direttamente da un sito web, comodamente dal vostro salotto, oppure di scaricare un certificato di stato di famiglia.


### PR DESCRIPTION
This PR removes the newsletters temporarily. 
As such:
* Disables the newsletter form in homepage.
* Removes the newsletter form from the `platform.html` layout.
* Removes the newsletter form from the contacts pages. 

@sebbalex 