### PR TITLE
Fixes #370 - text replacement for no keyword in search

### DIFF
--- a/_pages/en/search.md
+++ b/_pages/en/search.md
@@ -1,5 +1,5 @@
 ---
-title: Catalog
+title: Catalogue
 lang: en
 ref:
   val: search

--- a/_pages/en/search.md
+++ b/_pages/en/search.md
@@ -1,5 +1,5 @@
 ---
-title: You have searched for
+title: Catalog
 lang: en
 ref:
   val: search

--- a/_pages/it/search.md
+++ b/_pages/it/search.md
@@ -1,5 +1,5 @@
 ---
-title: Hai cercato
+title: Catalogo
 lang: it
 ref:
   val: search

--- a/_sass/search-page.scss
+++ b/_sass/search-page.scss
@@ -84,7 +84,7 @@
   .item {
     .category {
       img {
-        dispaly: inline;
+        display: inline;
       }
       p {
         text-transform: uppercase;

--- a/_sass/softwares.scss
+++ b/_sass/softwares.scss
@@ -62,7 +62,7 @@
   .results-number {
     font-weight: 600;
     p {
-      margin-top: auto;
+      margin-top: 0.5em;
     }
   }
 }

--- a/assets/scripts/esDevelopersItaliaQuery.js
+++ b/assets/scripts/esDevelopersItaliaQuery.js
@@ -526,7 +526,7 @@ function esDevelopersItaliaQuery(config, params) {
     },
     'intro_empty': {
       'it': 'Catalogo',
-      'en': 'Catalog'
+      'en': 'Catalogue'
     },
     'autocomplete_all_text': {
       'it': 'Cerca in tutto il sito',

--- a/assets/scripts/esDevelopersItaliaQuery.js
+++ b/assets/scripts/esDevelopersItaliaQuery.js
@@ -524,6 +524,10 @@ function esDevelopersItaliaQuery(config, params) {
       'it': 'Hai cercato',
       'en': 'You have searched for'
     },
+    'intro_empty': {
+      'it': 'Catalogo',
+      'en': 'Catalog'
+    },
     'autocomplete_all_text': {
       'it': 'Cerca in tutto il sito',
       'en': 'Search all over the site'
@@ -809,10 +813,13 @@ esDevelopersItaliaQuery.prototype.renderIntro = function (tot) {
   var keyword = decodeURI(this.params['keyword'].slice(0).pop());
   var language = this.config['language'];
   var $intro = $('.intro > h1');
-
+  
   if (keyword !== 'undefined') {
     $intro.text('');
     $intro.html(this.config['intro'][language] + ' "' + keyword.split('+').join(' ') + '"');
+  } else {
+    $intro.text('');
+    $intro.html(this.config['intro_empty'][language]);
   }
 };
 


### PR DESCRIPTION
This PR will:
- fixes #370
- fix typo in scss
- results and sortBy filter are now aligned horizontally in search page

and aims to discuss if text "Catalogo" is a good for replacement "Hai Cercato" in search page when no keyword is specified.