### PR TITLE
Fix #256 - APIs page indexed twice

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -153,6 +153,7 @@ page_gen:
     data: apis
     template: api-details
     defaults:
+      lang: it
       type: api
     dir: it/api
     #filter_condition: "record['language'].include? 'it'"
@@ -162,6 +163,7 @@ page_gen:
     data: apis
     template: api-details
     defaults:
+      lang: en
       type: api
     dir: en/api
     #filter_condition: "record['language'].include? 'en'"

--- a/_layouts/api-details.html
+++ b/_layouts/api-details.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-lang: it
+lang: {{ site.lang }}
 ---
 
 {% include setlang.html %}


### PR DESCRIPTION
Fixes #256 
APIs pages were set by default to lang `it` even if they were published under another language folder, this caused duplicated entries in search engine when website is set to ITA lang and no results with ENG lang.
Search engine will filter results based on language set in website so they should be visibile in both languages even if they are published in only one of them.