### PR TITLE
Remove GSoC

### DIFF
--- a/_data/menu_items.yml
+++ b/_data/menu_items.yml
@@ -21,9 +21,6 @@ it:
   - title: News
     url: '/it/news'
     active_by_firstlevel: 'news'
-  - title: GSoC 
-    url: '/it/idee-gsoc'
-    active_by_firstlevel: 'GSoC'
   - title: Contatti
     url: '/it/contatti'
     active_by_firstlevel: 'contatti'
@@ -51,9 +48,6 @@ en:
   - title: News
     url: '/en/news'
     active_by_firstlevel: 'news'
-  - title: GSoC 
-    url: '/en/gsoc-ideas'
-    active_by_firstlevel: 'GSoC'
   - title: Contacts
     url: '/en/contacts'
     active_by_firstlevel: 'contacts'


### PR DESCRIPTION
This PR:
* removes the GSoC entry from the menu;

Do you think we should remove also the pages? @sebbalex 
Maybe they could stay there without a menu link for future reference. 