### PR TITLE
Add cieid-android-sdk to the CIE page

### DIFF
--- a/_platforms/en/cie.md
+++ b/_platforms/en/cie.md
@@ -45,6 +45,10 @@ resources:
       url: https://github.com/italia/cie-middleware-linux
       desc: The middleware package allows to use the card for accessing web services protected by client authentication.
   - SDK:
+    - title: SDK for Android - Entra con CIE
+      icon: github
+      url: https://github.com/italia/cieid-android-sdk
+      desc: SDK for Android for the "Login with CIE" authentication method
     - title: CIE/CNS Apache Docker
       icon: settings
       url: https://github.com/italia/cie-cns-apache-docker

--- a/_platforms/it/cie.md
+++ b/_platforms/it/cie.md
@@ -45,6 +45,10 @@ resources:
       url: https://github.com/italia/cie-middleware-linux
       desc: Il middleware consente di usare la carta come strumento di accesso per i servizi web.
   - SDK:
+    - title: SDK per Android - Entra con CIE
+      icon: github
+      url: https://github.com/italia/cieid-android-sdk
+      desc: SDK per Android per l'integrazione del sistema di autenticazione Entra con CIE
     - title: CIE/CNS Apache Docker
       icon: settings
       url: https://github.com/italia/cie-cns-apache-docker


### PR DESCRIPTION
This PR adds the cieid-android-sdk repository to the CIE page.