### PR TITLE
[#554] Add title to internal-long layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .jekyll-metadata
 .sass-cache
+.bundle
 _data/github_members.json
 _data/github_teams.json
 _site

--- a/_layouts/internal-long.html
+++ b/_layouts/internal-long.html
@@ -11,8 +11,10 @@ layout: default
             {% if page.subtitle %}
             <h2>{{page.subtitle}}</h2>
             {%endif%}
-
+            
+            <div class="simplelayout-main-content my-2 my-md-5">
             {{ page.content }}
+            </div>
 
             {% if page.see_also.size > 0 %}
             <h4 class="mt-4">{{t.see_also}}</h4>

--- a/_layouts/internal-long.html
+++ b/_layouts/internal-long.html
@@ -7,8 +7,12 @@ layout: default
 <section class="project__content {% if page.resources %}with-resources{%endif%}">
     <div class="container d-flex justify-content-center">
         <div class="project__maincontent col-md-10">
+            <h1>{{page.title}}</h1>
+            {% if page.subtitle %}
+            <h2>{{page.subtitle}}</h2>
+            {%endif%}
 
-            {{ content }}
+            {{ page.content }}
 
             {% if page.see_also.size > 0 %}
             <h4 class="mt-4">{{t.see_also}}</h4>

--- a/_pages/en/reuse/acquisition.md
+++ b/_pages/en/reuse/acquisition.md
@@ -10,8 +10,6 @@ see_also:
     url: /en/reuse/publication
 ---
 
-## Software acquisition for Public Administrations 
-
 When acquiring software, public entities shall run a comparative evaluation
 following the process described by the [Guidelines]({{ site.url_lineeguidariuso }}).
 

--- a/_pages/en/reuse/publication.md
+++ b/_pages/en/reuse/publication.md
@@ -10,8 +10,6 @@ see_also:
     url: /en/reuse/acquisition
 ---
 
-## Publish software for Public Administration 
-
 When an Italian Public Administation develops or commissions software it must
 comply with the [art. 69 of the Codice dell'Amministrazione
 Digitale](https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo6_art69.html)

--- a/_pages/it/info-privacy-communitycall.md
+++ b/_pages/it/info-privacy-communitycall.md
@@ -1,12 +1,10 @@
 ---
 title: Informativa privacy
-subtitle: Informativa privacy - Community Call Developers Italia
+subtitle: Community Call Developers Italia
 lang: it
 layout: internal-long
 ---
 
-<h1> Informativa privacy </h1>
-<h2>Community Call Developers Italia</h2>
 La presente informativa viene resa ai sensi dell’art. 13 del Regolamento 2016/679 (GDPR) ed è relativa ai dati personali trattati nell’ambito delle
 community call di Developers Italia.
 

--- a/_pages/it/privacy-policy-18app.md
+++ b/_pages/it/privacy-policy-18app.md
@@ -1,12 +1,9 @@
 ---
-title: Privacy Policy sperimentazione 18app
+title: Informativa sul trattamento dei dati personali per la sperimentazione dell’applicazione mobile 18app
+subtitle: art. 13 del Regolamento UE n. 2016/679
 lang: it
 layout: internal-long
 ---
-
-# Informativa sul trattamento dei dati personali per la sperimentazione dell’applicazione mobile 18app
-
-_(art. 13 del Regolamento UE n. 2016/679)_
 
 Il Team per la Trasformazione Digitale presso la Presidenza del Consiglio dei Ministri (di seguito “Team”), ha sviluppato di concerto con il Ministero per i Beni e le Attività Culturali e per il Turismo (nel seguito “MIBACT”), l’applicazione mobile 18app.
 Prima di rendere disponibile a tutti i cittadini l’App, si ritiene utile effettuare una sperimentazione, coinvolgendo un numero limitato di volontari residenti a Roma e provincia al fine di raccogliere indicazioni e suggerimenti sull’utilizzo dell’applicazione. La sperimentazione dell’App comporta il consumo reale del bonus cultura dei partecipanti, quindi potranno essere effettuati acquisti reali online ed offline.

--- a/_pages/it/riuso/acquisizione.md
+++ b/_pages/it/riuso/acquisizione.md
@@ -10,8 +10,6 @@ see_also:
     url: /it/riuso/pubblicazione
 ---
 
-## Acquisizione di software per la Pubblica Amministrazione
- 
 Quando si acquisisce software le Pubbliche Amministrazioni devono effettuare una valutazione comparativa secondo il processo descritto dalle [Linee Guida]({{ site.url_lineeguidariuso }}).
 
 Tale processo privilegia il software open source (_a riuso_ o _di terze parti_) rispetto all'acquisizione di software in licenza d'uso, come previsto dal [Codice dell'Amministrazione Digitale](https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo6_art68.html). Le linee guida indicano espressamente il [catalogo di Developers Italia](/it/software) come piattaforma ove svolgere la ricerca.

--- a/_pages/it/riuso/pubblicazione.md
+++ b/_pages/it/riuso/pubblicazione.md
@@ -10,8 +10,6 @@ see_also:
     url: /it/riuso/acquisizione
 ---
 
-## Pubblicazione di software per la Pubblica Amministrazione
-
 Quando una Pubblica Amministrazione italiana sviluppa o commissiona software è tenuta, ai sensi dell'[art. 69 del Codice dell'Amministrazione Digitale](https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo6_art69.html), a pubblicarlo in repertorio pubblico con licenza aperta al fine di consentirne il riuso da parte di altre amministrazioni.
 
 Questo processo è dettagliatamente descritto nelle [linee guida per l'Acquisizione e il riuso di software]({{ site.url_lineeguidariuso }}) emesse dall'Agenzia per l'Italia Digitale. Gli [allegati tecnici](https://docs.italia.it/italia/developers-italia/lg-acquisizione-e-riuso-software-per-pa-docs/it/stabile/attachments/allegato-b-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa.html) delle linee guida sono formulati in modo da poter essere direttamente inclusi nei contratti e nei capitolati relativi allo sviluppo di software, alla modifica di software esistente e alla manutenzione di software, al fine di ottemperare all'obbligo di rilascio.


### PR DESCRIPTION
This PR:
* Adds the title in the `internal-long` layout
* Adds div that makes content in the `internal-long` layout inherit the `Lora` font and not the generic `Titillium web` reserved for the text outside layouts. 
* Also adds some top and bottom padding to the page.content

* Fixes #554
* Also Fixes #508