### PR TITLE
[#369] Change sw display ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :jekyll_plugins do
    gem 'jekyll-sitemap'
    gem 'jekyll-tagging'
    gem 'hawkins'
+   gem 'liquid-nested-sort', '~> 0.1.4'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
+    liquid-nested-sort (0.1.4)
+      liquid (>= 4.0, < 5.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -150,6 +152,7 @@ DEPENDENCIES
   jekyll-tagging
   jekyll-toc
   kramdown-parser-gfm
+  liquid-nested-sort (~> 0.1.4)
   minima (~> 2.5)
   octokit (~> 4.18)
   parallel

--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ plugins:
   - jekyll-toc
   - jekyll-sitemap
   - searchyll
+  - liquid-nested-sort
 exclude:
   - .circleci
   - AUTHORS

--- a/_includes/home-listing-sw.html
+++ b/_includes/home-listing-sw.html
@@ -1,7 +1,7 @@
 {% include setlang.html %}
 
 {% assign limititems = include.limit | default: 4 %}
-{% assign items = site.data.crawler.softwares | sort: "vitalityScore" | reverse %}
+{% assign items = site.data.crawler.softwares | sample: 4 %}
 
 {% assign title = include.title %}
 {% assign captiontitle = include.captiontitle %}
@@ -34,9 +34,9 @@
 
                     <a title="{{ sw_name }}" href="{{ sw_url }}" class="home-listing-item__imgwrapper w-100">
                     {% capture homeClasses %} home-listing-item__img w-100 {% endcapture %}
-                    {% include display-logo.html 
-                        logo = item.publiccode.logo 
-                        id = item.id 
+                    {% include display-logo.html
+                        logo = item.publiccode.logo
+                        id = item.id
                         screenshots = description.screenshots
                         classes = homeClasses
                         codiceIPA = item.publiccode.it.riuso.codiceIPA

--- a/_layouts/brand-pa.html
+++ b/_layouts/brand-pa.html
@@ -13,7 +13,7 @@ layout: default-pa
 {% include linklist.html items=subnav dynamic=true %}
 {% endcomment %}
 
-{% assign generic_sw = site.data.crawler.softwares | where_exp: "item", "item.publiccode.it.riuso.codiceIPA == page.ipa" | slice: 0, 60 %}
+{% assign generic_sw = site.data.crawler.softwares | where_exp: "item", "item.publiccode.it.riuso.codiceIPA == page.ipa" | nested_sort_natural: "publiccode.name" | slice: 0, 60 %}
 
 {% assign root = '/' | append: active_lang  %}
 


### PR DESCRIPTION
As mentioned in #369, the sw ordering should change.
As such, this PR changes the following:

- [x] Search results: it should be ordered by relevance and descending vitality
- [x] Home page: it should be ordered randomly
- [x] Public entity page: it should be ordered alphabetically
-  ~Software page: it should be ordered randomly~

Fix:
* Fixes #369 