### PR TITLE
[#532] Fix deprecation warnings on build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :jekyll_plugins do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data'
 
 gem 'searchyll', :git => 'https://github.com/italia/developers-italia-searchyll'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,4 +157,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,4 +157,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.0p0
 
 BUNDLED WITH
    2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,10 @@ GEM
       faraday (> 0.8, < 2.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2020.1)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -150,7 +154,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.6.3p62
 
 BUNDLED WITH
    2.0.1

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ download-data:
 	wget --max-redirect 0 https://crawler.developers.italia.it/software_tags.yml -O _data/crawler/software_tags.yml
 build-bundle:
 	gem install bundler
-	bundle install --path vendor/
+	bundle config set path vendor/
+	bundle install
 build-swagger:
 	cd swagger && npm run build
 test:


### PR DESCRIPTION
This PR:

- defining the path in the configuration instead of as a parameter in the install command (deprecated)
-  setting gem tzinfo-data for all systems instead for only the win systems

