### PR TITLE
Fix button alignment in /software page.

### DIFF
--- a/_includes/sw-pair-blocks.html
+++ b/_includes/sw-pair-blocks.html
@@ -3,30 +3,31 @@
 
 <section class="banner-joinus overflow-x-hidden">
     <div class="container">
-        <div class="row row-eq-height ">
+        <div class="card-deck">
             {% for block in blocks %}
             {% capture thecycle %}{% cycle 'odd', 'even' %}{% endcapture %}
             <div class="col-sm my-3 my-md-5 px-3">
-                <article class="d-flex flex-column align-items-start h-100 bg-white pt-4 pb-4">
-                    <div>
-                        {% if block.image %}
-                        <div class="text-center py-4 px-3" >
-                            <img src="{{block.image | relative_url}}" alt="{{block.title}}" class="img-fluid">
-                        </div>
-                        {% endif %}
-                        <h1 class="text-center px-2 px-md-4 mt-auto">{{block.title}}</h1>
-                        {% if block.text!=nil%}
-                        <div class="font-serif mt-1 mb-1 alternateblock__text text-center px-2 px-md-4">{{block.text | markdownify }}</div>                    
-                        {% endif %}
-                        {% if block.buttons!=nil%}
-                            <div class="mt-1 mt-md-2 mb-1 px-2 px-md-4 text-center">
-                                {% for button in block.buttons %}
-                                    <a href="{{button.url | escape }}" class="{{button.class}} mr-3 mt-2">{{button.label}}</a>
-                                {% endfor %}
-                            </div>
-                        {% endif %}
-                    </div>
-                </article>
+                <div class="card h-100">
+                      {% if block.image %}
+                      <div class="mb-auto text-center py-4 px-3" >
+                          <img src="{{block.image | relative_url}}" alt="{{block.title}}" class="img-fluid">
+                      </div>
+                      {% endif %}
+
+                      <div class="card-body d-flex flex-column">
+                          <h1 class="text-center px-2 px-md-4 mt-auto">{{block.title}}</h1>
+                          {% if block.text != nil%}
+                          <div class="flex-fill font-serif mt-1 mb-1 alternateblock__text text-center px-2 px-md-4">{{block.text | markdownify }}</div>
+                          {% endif %}
+                          {% if block.buttons != nil%}
+                              <div class="px-2 px-md-4 text-center">
+                                  {% for button in block.buttons %}
+                                      <a href="{{button.url | escape }}" class="{{button.class}} mr-3 mt-2">{{button.label}}</a>
+                                  {% endfor %}
+                              </div>
+                          {% endif %}
+                      </div>
+                </div>
             </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
Make the buttons and title be aligned across cards in
the /software page.

Fix #581.

After the patch:
![resize](https://user-images.githubusercontent.com/788293/89882439-1ffef980-dbc7-11ea-89fe-fc7f57575fac.gif)
![content-length](https://user-images.githubusercontent.com/788293/89882450-24c3ad80-dbc7-11ea-9b9e-3e99100c789a.gif)
