### PR TITLE
Remove deploy-vm target and its rsync dependecy.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ COPY package.json .
 # Temporarily set user to root
 USER root
 
-# Install required software
-RUN which rsync || sudo apt-get install rsync
+# rsync is needed by Swagger
+RUN apt-get install -y --no-install-recommends rsync \
+  && apt-get clean \
+  && rm -fr /var/lib/apt/lists/*
 
 # Run as unprivileged user
 RUN adduser --home ${HOME} --shell /bin/bash --disabled-password ${USER}

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ local:
 	JEKYLL_NO_GITHUB=true bundle exec jekyll serve --incremental --host=0.0.0.0
 jekyll-build:
 	JEKYLL_ENV=production bundle exec jekyll build
-deploy-vm:
-	rsync --delete -avP --exclude "Makefile" --rsync-path="sudo -u www-data rsync" _site/ developers.italia.it:/apps/www/developers.italia.it/web/
 include-npm-deps:
 	npm install
 build: | build-bundle include-npm-deps download-data build-swagger jekyll-build


### PR DESCRIPTION
Remove the obsolete deploy-vm Makefile target since the site is now
deployed using GitHub Pages.