### PR TITLE
Run the container as the specified user.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@
 JEKYLL_ENV=dev
 JEKYLL_NO_GITHUB=true
 NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+# Commands in the container will be run as this user,
+# set this variable to your uid and gid.
+#
+# RUNAS=1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM circleci/ruby:2.6.0-node-browsers
 
-# Env variables definition
-ENV USER developers
-ENV HOME /usr/src/developers.italia.it
 ENV PORT 4000
 
-# Set the work directory
-WORKDIR ${HOME}
+WORKDIR /usr/src/developers.italia.it
+
+USER root
+
+# rsync is needed by Swagger
+RUN apt-get install -y --no-install-recommends rsync \
+  && apt-get clean \
+  && rm -fr /var/lib/apt/lists/*
+
+USER ${RUNAS}
 
 # Copy useful files inside the workdir
 COPY .well-known .well-known
@@ -35,31 +40,11 @@ COPY Makefile .
 COPY package-lock.json .
 COPY package.json .
 
-# Temporarily set user to root
-USER root
-
-# rsync is needed by Swagger
-RUN apt-get install -y --no-install-recommends rsync \
-  && apt-get clean \
-  && rm -fr /var/lib/apt/lists/*
-
-# Run as unprivileged user
-RUN adduser --home ${HOME} --shell /bin/bash --disabled-password ${USER}
-
-# Set user ownership on workdir and subdirectories
-RUN chown -R ${USER}.${USER} ${HOME}
-
-# Fix permissions for Linux users
-RUN chmod a+rwx -R .
-
-# Set running user
-USER ${USER}
-
 RUN make include-npm-deps
 RUN make build-bundle
 RUN make download-data
 RUN make build-swagger
 
-EXPOSE ${PORT}
+EXPOSE 4000
 
 CMD ["make", "local"]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The website is developed using [Jekyll](https://jekyllrb.com/) and it's currentl
 
 A [CircleCI job](.circleci/config.yml) builds the sources and commits the resulting artifacts to GitHub, in the [gh-pages branch](https://github.com/italia/developers.italia.it/tree/gh-pages). The [same job](.circleci/config.yml) is also triggered every night to get the most updated data feeding the website.
 
-## Development 
+## Development
 
-A development environment can be both brought up directly on the developer machine and in form of a Docker container. 
+A development environment can be both brought up directly on the developer machine and in form of a Docker container.
 
 The same commands -run in the [Dockerfile](Dockerfile)- can also be run directly on the developer machine.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    user: "${RUNAS?Try $ echo RUNAS=$(id -u):$(id -g) >> .env}"
     env_file:
       - .env
     ports:


### PR DESCRIPTION
Support the RUNAS variable to run as the specified user.

The docker container is used only during development, ie. with the work
directory always bind mounted to a directory on the developer's box.
This means we want the container to always run as the current user and
RUNAS to be mandatory.

Fix #596.