### PR TITLE
Hardcode NOKOGIRI_USE_SYSTEM_LIBRARIES to true.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@
 #GITHUB_ACCESS_TOKEN=YOUR_OPTIONAL_GH_ACCESS_TOKEN
 JEKYLL_ENV=dev
 JEKYLL_NO_GITHUB=true
-NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # Commands in the container will be run as this user,
 # set this variable to your uid and gid.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM circleci/ruby:2.6.0-node-browsers
 
 ENV PORT 4000
+ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true
 
 WORKDIR /usr/src/developers.italia.it
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Some environment variables change the behavior of different aspects of your buil
 
 * **JEKYLL_ENV**: can be set either to *development* (default) or *production*. The latter minifies and optimizes the build artifacts
 
-* **NOKOGIRI_USE_SYSTEM_LIBRARIES**: can be either set to *true* or *false*. You usually want to set this to *true* (default). The [Nokogiri documentation](https://nokogiri.org/tutorials/installing_nokogiri.html#install-with-system-libraries) mentions that this allows to use the OS *libxml2* and *libxslt* libraries, instead of using the Nokogiri ones
-
 
 ## License
 


### PR DESCRIPTION
Set the variable to the reasonable value. The developer doesn't have
to care about Nokogiri's minutiae.