### PR TITLE
Use bundle install --deployment in test and production.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ references:
       name: install-dependencies
       command: |
         make include-npm-deps
-        make build-bundle
+        make bundle-install-deployment
         which rsync || sudo apt-get install rsync
 
   get_crawler_yml_files: &get_crawler_yml_files

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY package-lock.json .
 COPY package.json .
 
 RUN make include-npm-deps
-RUN make build-bundle
+RUN make bundle-install
 RUN make download-data
 RUN make build-swagger
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,17 @@ download-data:
 	wget --max-redirect 0 https://crawler.developers.italia.it/software-riuso.yml -O _data/crawler/software-riuso.yml
 	wget --max-redirect 0 https://crawler.developers.italia.it/software_scopes.yml -O _data/crawler/software_scopes.yml
 	wget --max-redirect 0 https://crawler.developers.italia.it/software_tags.yml -O _data/crawler/software_tags.yml
-build-bundle:
-	gem install bundler
+
+bundle-setup:
+	gem install bundler:2.1.4
 	bundle config set path vendor/
+
+bundle-install: bundle-setup
 	bundle install
+
+bundle-install-deployment: bundle-setup
+	bundle install --deployment
+
 build-swagger:
 	cd swagger && npm run build
 test:
@@ -21,5 +28,5 @@ jekyll-build:
 	JEKYLL_ENV=production bundle exec jekyll build
 include-npm-deps:
 	npm install
-build: | build-bundle include-npm-deps download-data build-swagger jekyll-build
+build: | build-bundle-deployment include-npm-deps download-data build-swagger jekyll-build
 build-test: | build test


### PR DESCRIPTION
When in test or production, bundle install must error out if
Gemfile.lock doesn't exist or doesn't match with it the Gemfile.

Pin the bundler version as well.