### PR TITLE
Add ELASTICSEARCH_FRONTEND_URL environment variable.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@
 #
 #ELASTICSEARCH_URL=http://devita_elasticsearch:9200
 
+# The Elasticsearch URL used for request in the browser, prefixed by
+# the HTTP schema (eg. http:// - https://).
+#
+# This is optional and not set to https://elasticsearch.developers.italia.it
+# by default.
+#
+#ELASTICSEARCH_FRONTEND_URL=https://elasticsearch.developers.italia.it
+
 # The optional Elasticsearch username.
 #
 # This is not set by default, as not all Elasticsearch servers authenticate users.

--- a/assets/js/esQuery.config.js
+++ b/assets/js/esQuery.config.js
@@ -1,4 +1,4 @@
-var elasticHost = 'https://elasticsearch.developers.italia.it';
+const elasticHost = process.env.ELASTICSEARCH_FRONTEND_URL;
 
 var paramKeys = [
   'publiccode.categories',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,6 +27,14 @@ module.exports = {
       PerfectScrollbar: 'perfect-scrollbar',
     }),
 
+    // Pass down environment variables to process.env.
+    //
+    // If a variable is set, its value takes precedence over
+    // the default value defined here.
+    new webpack.EnvironmentPlugin({
+      ELASTICSEARCH_FRONTEND_URL: 'https://elasticsearch.developers.italia.it',
+    }),
+
     // Just copy images and icons we reference directly in the HTML, we
     // don't need to bundle those.
     new CopyWebpackPlugin({


### PR DESCRIPTION
Use the ELASTICSEARCH_FRONTEND_URL if set to get the frontend
Elasticsearch URL instead of just hardcoding it.

Fix #625.