### PR TITLE
Refactor github_importer.rb and show teamdigitale in /en/to-do.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,14 +20,9 @@ gem "html-proofer"
 # install kramdown-parser-gfm (from kramdown version 2 this is needed)
 gem "kramdown-parser-gfm"
 
-# speed up parallel github fetches
-gem "parallel"
-
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
-
-gem "rest-client", "~> 2.1"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
@@ -46,4 +41,6 @@ gem 'tzinfo-data'
 
 gem 'searchyll', :git => 'https://github.com/italia/developers-italia-searchyll'
 
+# github_importer.rb dependencies
 gem "octokit", "~> 4.18"
+gem "rest-client", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,6 @@ DEPENDENCIES
   liquid-nested-sort (~> 0.1.5)
   minima (~> 2.5)
   octokit (~> 4.18)
-  parallel
   rest-client (~> 2.1)
   searchyll!
   tzinfo-data

--- a/assets/js/github-issues.js
+++ b/assets/js/github-issues.js
@@ -69,7 +69,7 @@ $(document).ready(function () {
                 "data": "labels", "render": function (data, type, row, meta) {
                     var labelist = '';
                     data.forEach(function (item) {
-                        labelist = labelist + "<span class='labelist u-color-white u-background-40 u-borderRadius-l u-padding-all-xxs u-margin-right-xxs u-margin-left-xxs u-margin-bottom-xxs' >" + item + " </span>";
+                        labelist = labelist + "<span class='badge badge-secondary mr-1' >" + item + " </span>";
                     });
                     return labelist;
                 }

--- a/scripts/github_importer.rb
+++ b/scripts/github_importer.rb
@@ -8,10 +8,10 @@ require 'parallel'
 require 'yaml'
 
 if ENV['GITHUB_ACCESS_TOKEN'] == "" || ENV['GITHUB_ACCESS_TOKEN'] == nil
-	puts "*****************************************************"
-	puts("WARNING! No GITHUB_ACCESS_TOKEN: skipping GitHub API calls")
-	puts "*****************************************************"
-	return
+  puts "*****************************************************"
+  puts("WARNING! No GITHUB_ACCESS_TOKEN: skipping GitHub API calls")
+  puts "*****************************************************"
+  return
 end
 
 feed_url = 'https://api.github.com'
@@ -20,36 +20,36 @@ access_token = ENV['GITHUB_ACCESS_TOKEN']
 site_folder = '_site/assets/'
 issues_types = ['bug','enhancement','new project', 'Hacktoberfest']
 tech_list = [
-	'angular', 'react', 'design', 'html', 'arduino', 'bootstrap', 'frontend',
-	'perl','python', 'cpp', 'scala', 'php', 'csharp', 'java', 'android', 'ios', 'dotnet',
-	'wordpress', 'metabase', 'ansible', 'docker', 'magento', 'joomla', 'django'
+  'angular', 'react', 'design', 'html', 'arduino', 'bootstrap', 'frontend',
+  'perl','python', 'cpp', 'scala', 'php', 'csharp', 'java', 'android', 'ios', 'dotnet',
+  'wordpress', 'metabase', 'ansible', 'docker', 'magento', 'joomla', 'django'
 ]
 blacklist_repos = []
 
 rest_params = {'per_page' => 100, 'page' => 1}
 if access_token!=nil
-	rest_params['access_token'] = access_token
+  rest_params['access_token'] = access_token
 end
 # obtaining all the repos of Italia Github org.
 repos_endpoint = feed_url + "/orgs/italia/repos"
 
 repos = []
 loop do
-	begin
-		repos_response = RestClient.get repos_endpoint, \
-			{params: rest_params.merge({type: 'public'}), accept: 'application/vnd.github.mercy-preview+json'}
-	rescue RestClient::Unauthorized, RestClient::Forbidden => err
-		puts "*****************************************************"
-		puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
-		puts err.response
-		return
-	else
-		puts "GITHUB API connection OK"
-		page_repos = JSON.parse(repos_response)
-		repos += page_repos
-		break if page_repos.size != rest_params['per_page']
-		rest_params['page'] += 1
-	end
+  begin
+    repos_response = RestClient.get repos_endpoint, \
+      {params: rest_params.merge({type: 'public'}), accept: 'application/vnd.github.mercy-preview+json'}
+  rescue RestClient::Unauthorized, RestClient::Forbidden => err
+    puts "*****************************************************"
+    puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
+    puts err.response
+    return
+  else
+    puts "GITHUB API connection OK"
+    page_repos = JSON.parse(repos_response)
+    repos += page_repos
+    break if page_repos.size != rest_params['per_page']
+    rest_params['page'] += 1
+  end
 end
 
 repos.size > 0 or puts("No repos fetched")
@@ -62,69 +62,69 @@ github_issues = []
 # For every repos we need the issues
 Parallel.each(repos, in_threads: 16) { |item|
 
-	open_issues = Integer(item['open_issues_count'])
-	name = item['name']
+  open_issues = Integer(item['open_issues_count'])
+  name = item['name']
 
-	# if this repo as no isseus or is blacklisted
-	next if open_issues == 0 or blacklist_repos.include? item['name']
+  # if this repo as no isseus or is blacklisted
+  next if open_issues == 0 or blacklist_repos.include? item['name']
 
-	# obtaining all the issues for this repo
-	issues_endpoint = feed_url + "/repos/italia/"+ name +"/issues"
-	rest_params['page'] = 0
+  # obtaining all the issues for this repo
+  issues_endpoint = feed_url + "/repos/italia/"+ name +"/issues"
+  rest_params['page'] = 0
 
-	# TODO: iterate over pages
-	begin
-		issues_response = RestClient.get issues_endpoint,{params: rest_params}
-	rescue RestClient::Unauthorized, RestClient::Forbidden => err
-		puts "*****************************************************"
-		puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
-		puts err.response
-		return
-	end
+  # TODO: iterate over pages
+  begin
+    issues_response = RestClient.get issues_endpoint,{params: rest_params}
+  rescue RestClient::Unauthorized, RestClient::Forbidden => err
+    puts "*****************************************************"
+    puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
+    puts err.response
+    return
+  end
 
-	issues = JSON.parse(issues_response)
+  issues = JSON.parse(issues_response)
 
-	issues.each do |issue|
-		# skip if the issues is also a PR
-		next if issue.key?("pull_request")
+  issues.each do |issue|
+    # skip if the issues is also a PR
+    next if issue.key?("pull_request")
 
-		issue_data = {}
-		# parent's data
-		issue_data[:name] = item['name']
-		issue_data[:language] = tech_list & item['topics']
-		issue_data[:repository_url] = item['html_url']
+    issue_data = {}
+    # parent's data
+    issue_data[:name] = item['name']
+    issue_data[:language] = tech_list & item['topics']
+    issue_data[:repository_url] = item['html_url']
 
-		# labels
-		issue_data[:labels] = issue['labels'].collect{ |label| label['name']}
-		# for now we want only issues tagged as "help wanted"
-		next if not issue_data[:labels].include?('help wanted')
-		# for now, strip the "help wanted from the list"
-		issue_data[:labels].delete('help wanted')
+    # labels
+    issue_data[:labels] = issue['labels'].collect{ |label| label['name']}
+    # for now we want only issues tagged as "help wanted"
+    next if not issue_data[:labels].include?('help wanted')
+    # for now, strip the "help wanted from the list"
+    issue_data[:labels].delete('help wanted')
 
-		# we've to analyze the name to obtain the projects and subproject
-		if issue_data[:name].start_with?(*projects_prefix)
-			issue_data[:project] = item['name'].partition('-').first
-			issue_data[:subproject] = item['name']
-		elsif projects_prefix.include? item['name']+'-'
-			issue_data[:project] = item['name']
-			issue_data[:subproject] = item['name']
-		elsif issue_data[:name].match(/.italia.it|\.gov.it/).to_s!=''
-			issue_data[:project] = 'website'
-			issue_data[:subproject] = item['name']
-		else
-			issue_data[:project] = 'other'
-			issue_data[:subproject] = item['name']
-		end
+    # we've to analyze the name to obtain the projects and subproject
+    if issue_data[:name].start_with?(*projects_prefix)
+      issue_data[:project] = item['name'].partition('-').first
+      issue_data[:subproject] = item['name']
+    elsif projects_prefix.include? item['name']+'-'
+      issue_data[:project] = item['name']
+      issue_data[:subproject] = item['name']
+    elsif issue_data[:name].match(/.italia.it|\.gov.it/).to_s!=''
+      issue_data[:project] = 'website'
+      issue_data[:subproject] = item['name']
+    else
+      issue_data[:project] = 'other'
+      issue_data[:subproject] = item['name']
+    end
 
-		issue_data[:url] = issue['html_url']
-		issue_data[:title] = issue['title']
-		issue_data[:created_at] = issue['created_at']
-		issue_data[:raw_labels] = issue['labels']
-		issue_data[:type] = (issue_data[:labels] & issues_types)[0]!=nil ? (issue_data[:labels] & issues_types)[0] : ''
-		issue_data[:severity] = ''
+    issue_data[:url] = issue['html_url']
+    issue_data[:title] = issue['title']
+    issue_data[:created_at] = issue['created_at']
+    issue_data[:raw_labels] = issue['labels']
+    issue_data[:type] = (issue_data[:labels] & issues_types)[0]!=nil ? (issue_data[:labels] & issues_types)[0] : ''
+    issue_data[:severity] = ''
 
-		github_issues.push(issue_data)
-	end
+    github_issues.push(issue_data)
+  end
 
 }
 puts "++++++++++++++ Github issues fetched: " + github_issues.size.to_s
@@ -134,7 +134,7 @@ teams_endpoint = feed_url + "/orgs/italia/teams"
 github_teams = []
 
 begin
-	teams_response = RestClient.get teams_endpoint,{params: rest_params}
+  teams_response = RestClient.get teams_endpoint,{params: rest_params}
 end
 teams = JSON.parse(teams_response)
 
@@ -142,23 +142,23 @@ teams = JSON.parse(teams_response)
 # unfortunately github api doesn't expose the full name of a member
 Parallel.each(teams, in_threads: 16) { |team|
 
-	team['members'] = []
+  team['members'] = []
 
-	# for every team we ask for members
-	begin
-		members_endpoint = team['url'] + '/members'
-		members_response = RestClient.get members_endpoint,{params: rest_params}
-	end
-	members = JSON.parse(members_response)
+  # for every team we ask for members
+  begin
+    members_endpoint = team['url'] + '/members'
+    members_response = RestClient.get members_endpoint,{params: rest_params}
+  end
+  members = JSON.parse(members_response)
 
-	Parallel.each(members, in_threads: 4) { |member|
-		begin
-			singlemember_response = RestClient.get member['url'],{params: rest_params}
-		end
-		team['members'].push( JSON.parse(singlemember_response) )
-	}
+  Parallel.each(members, in_threads: 4) { |member|
+    begin
+      singlemember_response = RestClient.get member['url'],{params: rest_params}
+    end
+    team['members'].push( JSON.parse(singlemember_response) )
+  }
 
-	github_teams.push(team)
+  github_teams.push(team)
 
 }
 puts "++++++++++++++ Github teams fetched: " + teams.size.to_s

--- a/scripts/github_importer.rb
+++ b/scripts/github_importer.rb
@@ -1,184 +1,158 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rest_client'
 require 'json'
 require 'octokit'
-require 'pathname'
-require 'parallel'
+require 'fileutils'
 require 'yaml'
 
-if ENV['GITHUB_ACCESS_TOKEN'] == "" || ENV['GITHUB_ACCESS_TOKEN'] == nil
-  puts "*****************************************************"
-  puts("WARNING! No GITHUB_ACCESS_TOKEN: skipping GitHub API calls")
-  puts "*****************************************************"
+# Export from these organizations
+ORGS = %w[teamdigitale italia].freeze
+
+# Project's prefixes we can translate to a user friendly string in the UI.
+# See todo_projects_dict in _data/l10n.yml.
+PROJECS_PREFIX = %w[spid- 18app anpr- daf- dati- pianotriennale- lg- design- security- cie-].freeze
+
+# List of technologies shown in the UI
+TECH_LIST = %w[
+  angular react design html arduino bootstrap frontend
+  perlpython cpp scala php csharp java android ios dotnet
+  wordpress metabase ansible docker magento joomla django
+].freeze
+
+# Import issues with at least one of these labels
+ONLY_WITH_LABEL = ['help wanted', 'Hacktoberfest'].freeze
+
+# Show these labels in the UI, if present.
+ISSUE_TYPES = ['bug', 'enhancement', 'new project', 'Hacktoberfest'].freeze
+
+# Ignore these repos using the full_name (ie. 'organization/repo')
+BLACKLISTED_REPOS = [].freeze
+
+GITHUB_ACCESS_TOKEN = ENV.fetch('GITHUB_ACCESS_TOKEN', '')
+
+def fetch(url, headers = {})
+  rest_params = {
+    'per_page' => 100,
+    'page' => 1,
+    'type' => 'public'
+  }
+
+  results = []
+  loop do
+    print "."
+    response = JSON.parse(RestClient.get(url, {
+      Authorization: "token #{GITHUB_ACCESS_TOKEN}", params: rest_params
+    }.merge(headers)))
+
+    if response.is_a? Array
+      results += response
+    else
+      results = response
+      break
+    end
+    break if response.size != rest_params['per_page']
+
+    rest_params['page'] += 1
+  end
+
+  results
+end
+
+def fetch_teams(org)
+  teams = fetch("https://api.github.com/orgs/#{org}/teams")
+
+  teams.map do |team|
+    members = fetch("#{team['url']}/members")
+
+    team['members'] = members.map { |m| fetch(m['url']) }
+    team
+  end
+end
+
+def fetch_issues(repos)
+  github_issues = []
+
+  repos.each do |repo|
+    open_issues, full_name = repo.values_at('open_issues_count', 'full_name')
+
+    next if open_issues.zero? || BLACKLISTED_REPOS.include?(full_name)
+
+    issues = fetch("https://api.github.com/repos/#{full_name}/issues")
+    issues.each do |issue|
+      next if issue.key?('pull_request')
+
+      labels = issue['labels'].map { |label| label['name'] }
+
+      # Only get the issues marked with at least one label in ONLY_WITH_LABEL
+      next unless labels.any? { |item| ONLY_WITH_LABEL.include? item }
+
+      issue_data = {
+        'created_at' => issue['created_at'],
+        'url' => issue['html_url'],
+        'title' => issue['title'],
+        'name' => repo['name'],
+        'language' => TECH_LIST & repo['topics'],
+        'repository_url' => repo['html_url'],
+        'labels' => labels,
+        'type' => (labels & ISSUE_TYPES).first || '',
+        'subproject' => repo['name']
+      }
+
+      # Remove the issue label(s) marking this as help wanted, so they don't
+      # get displayed in the UI.
+      issue_data['labels'].reject! { |label| ONLY_WITH_LABEL.include? label }
+
+      # Set the main project name.
+      # The user facing strings are translated in _data/l10n.yml.
+      prefix = PROJECS_PREFIX.find { |p| repo['name'].start_with?(p) }
+      issue_data['project'] = if prefix
+                                prefix.tr('-', '')
+                              elsif repo['name'] =~ /.italia.it|\.gov.it|\.governo\.it/
+                                'website'
+                              else
+                                'other'
+                              end
+      github_issues.push(issue_data)
+    end
+  end
+  github_issues
+end
+
+if GITHUB_ACCESS_TOKEN.empty?
+  warn '**********************************************************'
+  warn 'WARNING! No GITHUB_ACCESS_TOKEN: skipping GitHub API calls'
+  warn '**********************************************************'
   return
 end
 
-feed_url = 'https://api.github.com'
-projects_prefix = ['spid-', '18app', 'anpr-','daf-','dati-','pianotriennale-','lg-','design-','security-','cie-']
-access_token = ENV['GITHUB_ACCESS_TOKEN']
-site_folder = '_site/assets/'
-issues_types = ['bug','enhancement','new project', 'Hacktoberfest']
-tech_list = [
-  'angular', 'react', 'design', 'html', 'arduino', 'bootstrap', 'frontend',
-  'perl','python', 'cpp', 'scala', 'php', 'csharp', 'java', 'android', 'ios', 'dotnet',
-  'wordpress', 'metabase', 'ansible', 'docker', 'magento', 'joomla', 'django'
-]
-blacklist_repos = []
+repos = ORGS.map do |org|
+  fetch(
+    "https://api.github.com/orgs/#{org}/repos", {
+      accept: 'application/vnd.github.mercy-preview+json'
+    }
+  )
+end.flatten
+puts "Got #{repos.size} GitHub repos"
 
-rest_params = {'per_page' => 100, 'page' => 1}
-if access_token!=nil
-  rest_params['access_token'] = access_token
-end
-# obtaining all the repos of Italia Github org.
-repos_endpoint = feed_url + "/orgs/italia/repos"
+github_issues = fetch_issues(repos)
+puts "Got #{github_issues.size} issues"
 
-repos = []
-loop do
-  begin
-    repos_response = RestClient.get repos_endpoint, \
-      {params: rest_params.merge({type: 'public'}), accept: 'application/vnd.github.mercy-preview+json'}
-  rescue RestClient::Unauthorized, RestClient::Forbidden => err
-    puts "*****************************************************"
-    puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
-    puts err.response
-    return
-  else
-    puts "GITHUB API connection OK"
-    page_repos = JSON.parse(repos_response)
-    repos += page_repos
-    break if page_repos.size != rest_params['per_page']
-    rest_params['page'] += 1
-  end
-end
+github_teams = fetch_teams('italia')
+puts "Got #{github_teams.size} teams"
 
-repos.size > 0 or puts("No repos fetched")
-repos.size > 0 or return
-
-puts "++++++++++++++ Github Repos fetched: " + repos.size.to_s
-
-github_issues = []
-
-# For every repos we need the issues
-Parallel.each(repos, in_threads: 16) { |item|
-
-  open_issues = Integer(item['open_issues_count'])
-  name = item['name']
-
-  # if this repo as no isseus or is blacklisted
-  next if open_issues == 0 or blacklist_repos.include? item['name']
-
-  # obtaining all the issues for this repo
-  issues_endpoint = feed_url + "/repos/italia/"+ name +"/issues"
-  rest_params['page'] = 0
-
-  # TODO: iterate over pages
-  begin
-    issues_response = RestClient.get issues_endpoint,{params: rest_params}
-  rescue RestClient::Unauthorized, RestClient::Forbidden => err
-    puts "*****************************************************"
-    puts("WARNING!!! Rate-limit problem with Github API provide a valid GITHUB_ACCESS_TOKEN in ENV variables")
-    puts err.response
-    return
-  end
-
-  issues = JSON.parse(issues_response)
-
-  issues.each do |issue|
-    # skip if the issues is also a PR
-    next if issue.key?("pull_request")
-
-    issue_data = {}
-    # parent's data
-    issue_data[:name] = item['name']
-    issue_data[:language] = tech_list & item['topics']
-    issue_data[:repository_url] = item['html_url']
-
-    # labels
-    issue_data[:labels] = issue['labels'].collect{ |label| label['name']}
-    # for now we want only issues tagged as "help wanted"
-    next if not issue_data[:labels].include?('help wanted')
-    # for now, strip the "help wanted from the list"
-    issue_data[:labels].delete('help wanted')
-
-    # we've to analyze the name to obtain the projects and subproject
-    if issue_data[:name].start_with?(*projects_prefix)
-      issue_data[:project] = item['name'].partition('-').first
-      issue_data[:subproject] = item['name']
-    elsif projects_prefix.include? item['name']+'-'
-      issue_data[:project] = item['name']
-      issue_data[:subproject] = item['name']
-    elsif issue_data[:name].match(/.italia.it|\.gov.it/).to_s!=''
-      issue_data[:project] = 'website'
-      issue_data[:subproject] = item['name']
-    else
-      issue_data[:project] = 'other'
-      issue_data[:subproject] = item['name']
-    end
-
-    issue_data[:url] = issue['html_url']
-    issue_data[:title] = issue['title']
-    issue_data[:created_at] = issue['created_at']
-    issue_data[:raw_labels] = issue['labels']
-    issue_data[:type] = (issue_data[:labels] & issues_types)[0]!=nil ? (issue_data[:labels] & issues_types)[0] : ''
-    issue_data[:severity] = ''
-
-    github_issues.push(issue_data)
-  end
-
-}
-puts "++++++++++++++ Github issues fetched: " + github_issues.size.to_s
-
-# FETCH TEAMS and MEMBERS
-teams_endpoint = feed_url + "/orgs/italia/teams"
-github_teams = []
-
-begin
-  teams_response = RestClient.get teams_endpoint,{params: rest_params}
-end
-teams = JSON.parse(teams_response)
-
-# for every team we need the members
-# unfortunately github api doesn't expose the full name of a member
-Parallel.each(teams, in_threads: 16) { |team|
-
-  team['members'] = []
-
-  # for every team we ask for members
-  begin
-    members_endpoint = team['url'] + '/members'
-    members_response = RestClient.get members_endpoint,{params: rest_params}
-  end
-  members = JSON.parse(members_response)
-
-  Parallel.each(members, in_threads: 4) { |member|
-    begin
-      singlemember_response = RestClient.get member['url'],{params: rest_params}
-    end
-    team['members'].push( JSON.parse(singlemember_response) )
-  }
-
-  github_teams.push(team)
-
-}
-puts "++++++++++++++ Github teams fetched: " + teams.size.to_s
-
-# FETCH ORG MEMBERS
-client = Octokit::Client.new(:access_token => access_token)
+# Fetch org members
+client = Octokit::Client.new(access_token: GITHUB_ACCESS_TOKEN)
 client.auto_paginate = true
-github_members = client.organization_public_members('italia').map {|x| x.to_hash}
-puts "++++++++++++++ Github members fetched: " + github_members.size.to_s
 
-# Repos&issues json must be in a specific folder cause we need a client parsing on the "cosa fare" page
-unless File.directory?(site_folder)
-  FileUtils.mkdir_p(site_folder)
-end
+github_members = client.organization_public_members('italia').map { |m| m.to_hash.transform_keys(&:to_s) }
+puts "Got #{github_members.size} members"
 
-File.open("#{site_folder}/github_issues.json", 'w') {|f| f.write(github_issues.to_json) }
+# We'll get this file from the frontend.
+FileUtils.mkdir_p('_site/assets')
+File.open('_site/assets/github_issues.json', 'w') { |f| f.write(github_issues.to_json) }
 
-github_teams.map!{ |team| Hash[team.map{ |k, v| [k.to_s, v] }] }
-github_members.map!{ |member| Hash[member.map{ |k, v| [k.to_s, v] }] }
-
-File.open("_data/github_teams.yml", 'w') {|f| f.write(github_teams.to_yaml) }
-File.open("_data/github_members.yml", 'w') {|f| f.write(github_members.to_yaml) }
-File.open("_data/github_tech_list.yml", 'w') {|f| f.write(tech_list.to_yaml) }
+File.open('_data/github_teams.yml', 'w') { |f| f.write(github_teams.to_yaml) }
+File.open('_data/github_members.yml', 'w') { |f| f.write(github_members.to_yaml) }
+File.open('_data/github_tech_list.yml', 'w') { |f| f.write(TECH_LIST.to_yaml) }


### PR DESCRIPTION
* Support multiple organizations
* Get all issues labeled with EITHER 'help wanted' or 'Hacktoberfest',
  not just 'help wanted'.
* Remove parallelism cause GitHub explicitly says not to use it.

Fix #662.