### PR TITLE
administration category in search page was statically linked

### DIFF
--- a/assets/js/esDevelopersItaliaQuery.js
+++ b/assets/js/esDevelopersItaliaQuery.js
@@ -1027,6 +1027,7 @@ esDevelopersItaliaQuery.prototype.renderPost = function (post) {
 esDevelopersItaliaQuery.prototype.renderAdministration = function (administration) {
   var screenshot = '/assets/images/cover_amministrazioni.png';
   var language = this.config['language'];
+  var category = DISE.categories["administration"];
 
   var data = {
     'name': administration["it-riuso-codiceIPA-label"],
@@ -1034,7 +1035,7 @@ esDevelopersItaliaQuery.prototype.renderAdministration = function (administratio
     'language': language,
     'screenshot': screenshot,
     'readMore': this.readMore[language],
-    'category': 'administration',
+    'category': category[language].toUpperCase(),
     'categoryClass': ['icon', 'icon-type-administration'].join(' '),
     'path': '/' + language + '/pa/' + administration["it-riuso-codiceIPA"]
   };


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #679 , this PR tackles:
* Administration category in search page was statically set to "administration", now it is localized and themed like others.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [X] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [X] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally?
- [X] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #679 
