### PR TITLE
Properly document GITHUB_ACCESS_TOKEN and remove JEKYLL_NO_GITHUB.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,14 +25,14 @@
 #
 #ELASTICSEARCH_PASS=YOUR_OPTIONAL_ES_PASSWORD
 
-# Disable data download from GitHub.
+# The optional GitHub API token to fetch data used in some pages.
 #
-# Set to false or unset it to enable data download.
-JEKYLL_NO_GITHUB=true
-
-# The optional GitHub access token to gain unlimited access GitHub API.
-# Access tokens are associated with the Italia GitHub account.
+# If you don't provide one, data won't be downloaded and the pages using it
+# will miss some content. In might be fine in development, but you have
+# to set it in production.
 #
+# It needs to be a token within @italia organization to get the full data
+# and members of the org.
 #GITHUB_ACCESS_TOKEN=YOUR_OPTIONAL_GH_ACCESS_TOKEN
 
 # The Jekyll environment.


### PR DESCRIPTION
Properly document GITHUB_ACCESS_TOKEN in .env.example and
remove JEKYLL_NO_GITHUB since it's no longer used.