### PR TITLE
[#699] Updated heading background images on .simplelayout

### DIFF
--- a/_layouts/internal-simple.html
+++ b/_layouts/internal-simple.html
@@ -5,7 +5,8 @@ layout: default
 {% include setlang.html %}
 
 <div class="simplelayout-main-image text-center">
-  <img src="{{page.image}}" class="img-fluid">
+	<div class="simplelayout-main-image-container" style="background-image: url('{{page.image}}');">
+	</div>
 </div>
 <div class="simplelayout-first-part">
   <div class="container d-flex justify-content-center">

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1045,7 +1045,7 @@ body {
         background-repeat: no-repeat;
         background-position: center;
         margin: 0;
-        @include bootstrap.media-breakpoint-up(lg) {
+        @media (min-width: 1600px) {
             margin: 0 15%;
         }
     }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1046,7 +1046,7 @@ body {
         background-position: center;
         margin: 0;
         @include bootstrap.media-breakpoint-up(lg) {
-          margin: 0 15%;
+            margin: 0 15%;
         }
     }
     &-first-part {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1033,6 +1033,21 @@ body {
 .simplelayout {
     &-main-image {
         background-color: #eee;
+        position: absolute;
+        width: 100%;
+        min-height: 405px;
+        display: grid;
+    }
+    &-main-image-container {
+        max-width: 100%;
+        height: auto;
+        background-size: cover;
+        background-repeat: no-repeat;
+        background-position: center;
+        margin: 0;
+        @include bootstrap.media-breakpoint-up(lg) {
+          margin: 0 15%;
+        }
     }
     &-first-part {
         background-color: #FAFBFD;
@@ -1043,12 +1058,12 @@ body {
         padding-bottom: 6rem;
     }
     &-main-text {
-        position: relative;
-        margin-top: -3rem;
-        padding: 1rem;
-        background-color: #fff;
-        z-index: 10;
-        box-shadow: 0 10px 80px 0 rgba(90, 103, 114, 0.1);
+      position: relative;
+      margin-top: 13rem;
+      padding: 1rem;
+      background-color: #fff;
+      z-index: 10;
+      box-shadow: 0 10px 80px 0 rgba(90,103,114,.1);
         h1 {
             font-size: 2.5rem;
             color: #17324D;
@@ -1070,7 +1085,7 @@ body {
         }
         @include bootstrap.media-breakpoint-up(md) {
             padding: 4rem;
-            margin-top: -6rem;
+            margin-top: 18rem;
         }
         h2 {
             font-weight: 400;
@@ -1434,7 +1449,7 @@ body {
             margin-top: 5px;
             overflow: hidden;
             width: 100%;;
-            @include bootstrap.media-breakpoint-up(md) {    
+            @include bootstrap.media-breakpoint-up(md) {
                 height: 145px;
                 object-fit: cover;
                 box-shadow: 0 10px 58px 0 rgba(90, 103, 114, 0.2);


### PR DESCRIPTION
## Description
As already mentioned in # 699, this PR corrects the display of the images present at the beginning of the "Simplelayout".

Such as?
Added a `div` that contains a background image, i.e. the header image. This `div` has replaced the `img` tag previously present and has a minimum height of 405px and is responsive on width.

**Before:** ![image_before_1](https://user-images.githubusercontent.com/7593569/94287956-31257f00-ff57-11ea-9354-012077e2bd1f.PNG)

**After:** 
![image_after_1](https://user-images.githubusercontent.com/7593569/94288069-4b5f5d00-ff57-11ea-8f5e-c303f949469b.PNG)



## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [ x ] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [ x ] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [ x ] Have you written new tests for your core changes, as applicable?
- [ x ] Have you successfully ran tests with your changes locally?
- [ x ] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #699 
