### PR TITLE
[#692] Use github resizing url for avatars

### DIFF
--- a/_includes/community-leaders.html
+++ b/_includes/community-leaders.html
@@ -5,36 +5,38 @@
 <div class="row">
     {% assign platforms = site.platforms | where: 'lang', active_lang | sort: 'title' %}
     {% for platform in platforms %}
-        {% if platform.github_team == nil or platform.github_team == "" %}
-            {% continue %}
-        {% endif %}
 
-        {% assign teams = site.data.github_teams | where: "slug", platform.github_team %}
-        {% assign team = teams.first %}
+    {% if platform.github_team == nil or platform.github_team == "" %}
+    {% continue %}
+    {% endif %}
 
-        {% if team == nil %}
-            {% continue %}
-        {% endif %}
+    {% assign teams = site.data.github_teams | where: "slug", platform.github_team %}
+    {% assign team = teams.first %}
 
-        {% assign members = team.members | sort: "name" %}
-        {% for member in members %}
-            {% if exclude contains member.name %}
-                {% continue %}
-            {% endif %}
+    {% if team == nil %}
+    {% continue %}
+    {% endif %}
 
-            <div class="credits-communityleader col-sm-4">
-                <div class="credits-communityleader-img">
-                    <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}&s=50" class="img-fluid"></a>
-                </div>
-                <div class="credits-communityleader-info">
-                    <div class="credits-communityleader-name">
-                        {{ member.name | default: member.login }}
-                    </div>
-                    <div class="credits-communityleader-role">
-                        {{ team.name }}
-                    </div>
-                </div>
+    {% assign members = team.members | sort: "name" %}
+    {% for member in members %}
+
+    {% if exclude contains member.name %}
+    {% continue %}
+    {% endif %}
+
+    <div class="credits-communityleader col-sm-4">
+        <div class="credits-communityleader-img">
+            <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}&s=50" class="img-fluid"></a>
+        </div>
+        <div class="credits-communityleader-info">
+            <div class="credits-communityleader-name">
+                {{ member.name | default: member.login }}
             </div>
-        {% endfor %}
+            <div class="credits-communityleader-role">
+                {{ team.name }}
+            </div>
+        </div>
+    </div>
+    {% endfor %}
     {% endfor %}
 </div>

--- a/_includes/community-leaders.html
+++ b/_includes/community-leaders.html
@@ -5,38 +5,36 @@
 <div class="row">
     {% assign platforms = site.platforms | where: 'lang', active_lang | sort: 'title' %}
     {% for platform in platforms %}
+        {% if platform.github_team == nil or platform.github_team == "" %}
+            {% continue %}
+        {% endif %}
 
-    {% if platform.github_team == nil or platform.github_team == "" %}
-    {% continue %}
-    {% endif %}
+        {% assign teams = site.data.github_teams | where: "slug", platform.github_team %}
+        {% assign team = teams.first %}
 
-    {% assign teams = site.data.github_teams | where: "slug", platform.github_team %}
-    {% assign team = teams.first %}
+        {% if team == nil %}
+            {% continue %}
+        {% endif %}
 
-    {% if team == nil %}
-    {% continue %}
-    {% endif %}
+        {% assign members = team.members | sort: "name" %}
+        {% for member in members %}
+            {% if exclude contains member.name %}
+                {% continue %}
+            {% endif %}
 
-    {% assign members = team.members | sort: "name" %}
-    {% for member in members %}
-
-    {% if exclude contains member.name %}
-    {% continue %}
-    {% endif %}
-
-    <div class="credits-communityleader col-sm-4">
-        <div class="credits-communityleader-img">
-            <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}" width="130" class="img-fluid"></a>
-        </div>
-        <div class="credits-communityleader-info">
-            <div class="credits-communityleader-name">
-                {{ member.name | default: member.login }}
+            <div class="credits-communityleader col-sm-4">
+                <div class="credits-communityleader-img">
+                    <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}&s=50" class="img-fluid"></a>
+                </div>
+                <div class="credits-communityleader-info">
+                    <div class="credits-communityleader-name">
+                        {{ member.name | default: member.login }}
+                    </div>
+                    <div class="credits-communityleader-role">
+                        {{ team.name }}
+                    </div>
+                </div>
             </div>
-            <div class="credits-communityleader-role">
-                {{ team.name }}
-            </div>
-        </div>
-    </div>
-    {% endfor %}
+        {% endfor %}
     {% endfor %}
 </div>

--- a/_includes/community.html
+++ b/_includes/community.html
@@ -1,5 +1,5 @@
 <div class="community-members">
     {% for member in site.data.github_members | sort: "login" %}
-    <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}" /></a>
+        <a href="{{ member.html_url }}"><img src="{{ member.avatar_url }}&s=50" /></a>
     {% endfor %}
 </div>

--- a/_includes/github_team_members.html
+++ b/_includes/github_team_members.html
@@ -18,7 +18,7 @@
 
 					<li class="d-flex project__leaders__item mb-3">
 						<a href="{{member.html_url}}" title="{{member.login}}" target="_blank"><img width="50"
-								src="{{member.avatar_url}}"></a>
+								src="{{member.avatar_url}}&s=50"></a>
 						<div class="ml-2 d-flex">
 							<a href="{{member.html_url}}" title="{{member.login}}" target="_blank"
 								class="align-self-center">{{member.name | default: member.login}}</a>


### PR DESCRIPTION
Use the resizing parameter of github urls instead of getting big images and resizing them after.

## Description
As already mentioned in #692 this PR tackles:
* Using the parameter `s=` of Github's avatar url to resize the image

## Checklist
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
- Fixes #692 
