### PR TITLE
Use italia/publiccode-tools-elasticsearch.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,16 @@
 # The Elasticsearch URL prefixed by the HTTP schema (eg. http:// - https://).
 #
 # If not set, Jekyll will exclude the Searchyll integration from the build.
-# This is optional and not set by default.
 #
-#ELASTICSEARCH_URL=http://devita_elasticsearch:9200
+ELASTICSEARCH_URL=http://elasticsearch:9200
 
 # The Elasticsearch URL used for request in the browser, prefixed by
 # the HTTP schema (eg. http:// - https://).
 #
-# This is optional and not set to https://elasticsearch.developers.italia.it
-# by default.
+# This is optional and will default to https://elasticsearch.developers.italia.it
+# if not set.
 #
-#ELASTICSEARCH_FRONTEND_URL=https://elasticsearch.developers.italia.it
+ELASTICSEARCH_FRONTEND_URL=http://localhost:9200
 
 # The optional Elasticsearch username.
 #
@@ -45,4 +44,4 @@
 # Commands in the container will be run as this user,
 # set this variable to your uid and gid.
 #
-# RUNAS=1000:1000
+#RUNAS=1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ WORKDIR /usr/src/developers.italia.it
 
 USER root
 
+RUN apt-get update \
+    && apt-get install -y wait-for-it \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 USER ${RUNAS}
 
 # Copy useful files inside the workdir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   elasticsearch:
-    image: italia/publiccode-tools-elasticsearch:latest
+    image: italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
     ports:
       - 9200:9200
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,13 @@ version: '3.3'
 
 services:
 
+  elasticsearch:
+    image: italia/publiccode-tools-elasticsearch:latest
+    ports:
+      - 9200:9200
+    networks:
+      - overlay
+
   devita_website:
     image: italia/developers.italia.it
     container_name: devita_website
@@ -27,7 +34,9 @@ services:
       - /usr/src/developers.italia.it/_data/crawler
       - /usr/src/developers.italia.it/node_modules
       - /usr/src/developers.italia.it/vendor
-    command: ["make", "local"]
+    depends_on:
+      - elasticsearch
+    command: ["wait-for-it", "elasticsearch:9200", "--timeout=60", "--", "make", "local"]
     networks:
       - overlay
 


### PR DESCRIPTION
Use our custom Elasticsearch image with preloaded data in the
development environment.