### PR TITLE
[#723] Icon wrapper rendering fix

### DIFF
--- a/_includes/share.html
+++ b/_includes/share.html
@@ -9,7 +9,8 @@
     {% if social[1].sharelink %}
       {% assign shareurl = page.url | absolute_url | escape %}
       <li class="list-inline-item">
-        <a href="{{ social[1].sharelink | replace: '<url>', shareurl }}" class="icon-wrapper" title=""><span class="icon it-{{ social[0] }}"></span>
+        <a href="{{ social[1].sharelink | replace: '<url>', shareurl }}" class="icon-wrapper" title="">
+          <svg class="icon icon-white"><use xlink:href="/assets/svg/sprite.svg#it-{{ social[0] }}"></use></svg>
           <span class="sr-only">{{ social[1].name | capitalize }}</span>
         </a>
       </li>

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1580,7 +1580,7 @@ body {
         .icon-wrapper {
             display: inline-block;
             padding-left: 0.5rem;
-            padding-right: 0.3rem;
+            padding-right: 0.5rem;
             padding-top: 0.5rem;
             padding-bottom: 0.5rem;
             border-radius: 100%;


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #723 , this PR tackles:
* Renders the correct icon.
* There was unequal padding, which made the icon wrapper shape irregular. Changed it the correct value.

The icons render like following now:
![Screenshot_2020-09-30 Terminato l’Hacktoberfest 2019, tiriamo le somme(3)](https://user-images.githubusercontent.com/28699912/94674260-884f9900-0335-11eb-9f71-574960f86777.png)
- [x] Ready to review and merge.
## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #723 
