### PR TITLE
[#730] Fixed news category close icon and centered category text

### DIFF
--- a/_layouts/posts_by_tag.html
+++ b/_layouts/posts_by_tag.html
@@ -22,7 +22,10 @@ lang: it
       <h1 >{{ t.news_title }}</h1>
       <div class="postslisting__filtertag ml-auto mb-2 d-flex flex-column flex-md-row">
         <a href="#" class="align-self-center d-flex order-2 order-md-1 " data-activate-element data-activeid="filterTags">{{ t.news_filter }} <span class="ml-3 it-expand"></span><span class="ml-3 it-collapse"></span></a>
-        <a href="./" title="{{ t.news_title }}" class="align-self-center d-flex postslisting__seltag ml-3 ml-md-4 mt-2 mt-md-0 order-1 order-md-2">{{ page.tag }} <span class="icon it-close"></span></a>
+        <a href="./" title="{{ t.news_title }}" class="align-self-center d-flex postslisting__seltag ml-3 ml-md-4 mt-2 mt-md-0 order-1 order-md-2">
+          <span class="align-self-center">{{ page.tag }}</span>
+          <svg class="icon icon-white"><use xlink:href="/assets/svg/sprite.svg#it-close"></use></svg>
+        </a>
       </div>
     </div>
     <div class="container postslisting__tags deactive" data-activatedby="filterTags">


### PR DESCRIPTION
## Description
This PR fixes the `close` icon in the news category filter and it also centers the category name.

Before:
![image](https://user-images.githubusercontent.com/9085116/94844693-eb692a80-041e-11eb-91b0-edd198bfe664.png)
After:
![image](https://user-images.githubusercontent.com/9085116/94844742-fde36400-041e-11eb-8083-29406084093b.png)



## Checklist
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] The documentation related to the proposed change has been updated accordingly (also comments in code). 
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
- Fixes #730
