### PR TITLE
#688 [ Fixed ] "Community leaders" Does not have "Dot" Pagination

### DIFF
--- a/_includes/github_team_members.html
+++ b/_includes/github_team_members.html
@@ -35,12 +35,15 @@
 		<div class="carousel-footer mt-auto d-flex">
 
 			<ol class="carousel-indicators align-self-center">
-				{% assign indicators = team_members.size | modulo: 3 %}
-				{% assign checkIndicators = indicators | times: 3 %}
+        {% assign indicators = team_members.size | modulo: 3 %}
+        {% if team_members.size > 5 %}
+        {% assign indicators = team_members.size | modulo: 4 %}
+        {% endif %}
+        {% assign checkIndicators = indicators | times: 3 %}
 
 				{% for item in (1..indicators) %}
 				<li data-target="#projectLeadersIndicator" data-slide-to="{{forloop.index0}}"
-					{% if forloop.first %}class="active" {%endif%}></li>
+					{% if forloop.first %} class="active" {% endif %}></li>
 				{% endfor %}
 				{% if checkIndicators < team_members.size  %}
 				<li data-target="#projectLeadersIndicator" data-slide-to="{{indicators}}"></li>

--- a/_includes/github_team_members.html
+++ b/_includes/github_team_members.html
@@ -35,11 +35,8 @@
 		<div class="carousel-footer mt-auto d-flex">
 
 			<ol class="carousel-indicators align-self-center">
-        {% assign indicators = team_members.size | modulo: 3 %}
-        {% if team_members.size > 5 %}
-        {% assign indicators = team_members.size | modulo: 4 %}
-        {% endif %}
-        {% assign checkIndicators = indicators | times: 3 %}
+        {% assign indicators = team_members.size | divided_by: 3.0 | ceil %}
+				{% assign checkIndicators = indicators | times: 3 %}
 
 				{% for item in (1..indicators) %}
 				<li data-target="#projectLeadersIndicator" data-slide-to="{{forloop.index0}}"


### PR DESCRIPTION
## Description

The github member navigation in the sections within "Platforms" now works correctly.

The problem was that the variable `indicators` always arrived as 0 when the team members were 6 or more, and it did not correctly perform the comparison to add more navigation circles in the carrousel, since it began to count from 1 in the following way `{1...indicators}`.

One more module was assigned when the number of team members is greater than 5.

## Checklist

- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
- Fixes #688 
