### PR TITLE
Pull request for issue: "More tags" button in the homepage has wrong …

### DIFF
--- a/_includes/home-software-categories.html
+++ b/_includes/home-software-categories.html
@@ -19,7 +19,7 @@
 
         {% if site.data.crawler.software_categories.size > 15 %}
         <div class="text-center mb-2 mb-md-4">
-            <a href="#" id="moreTags" class="home-software-tags__extra">{{ t.home_tags_more }}</a>
+            <a href="#" id="moreTags" class="btn btn-primary mx-auto">{{ t.home_tags_more }}</a>
         </div>
         {% endif %}
     </div>

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -953,17 +953,6 @@ body {
             margin: 3.5rem 0;
         }
     }
-    &__extra {
-        font-weight: 600;
-        color: #fff;
-        background-color: #5C6F82;
-        padding: 0.3rem 1rem;
-        border-radius: 0.25rem;
-        &:hover {
-            color: #fff;
-            text-decoration: none;
-        }
-    }
     &__item {
         display: inline-block;
         margin-right: 0.5rem;


### PR DESCRIPTION
…style #760

I've just copied the styling of the other buttons and replaced the class that the a element previously had.

<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #760 , this PR tackles:

- Button "More Tags" has different styling from the other buttons.
- To tackle this issue I've copied the styling from the previous buttons and replaced the existing class for the copied ones, making the styling the same as the rest.
![Capture](https://user-images.githubusercontent.com/11543544/95501864-dcdfbd80-09a0-11eb-8773-43490d67677e.JPG)



## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #760
