### PR TITLE
Properly size logos in thumbnails.

### DIFF
--- a/_includes/display-logo.html
+++ b/_includes/display-logo.html
@@ -38,10 +38,10 @@ Utility functions are located in assets/scripts/logos.js.
 >
   <div
     style="
-      background-position: top center;
+      background-position: center;
       background-repeat: no-repeat;
-      background-size: cover;
-      height:150px;
+      background-size: 100% !important;
+      height: 150px;
       background-image: url('{{ placeholderScreen}}');
     "
   ></div>

--- a/assets/js/search.handlebars
+++ b/assets/js/search.handlebars
@@ -8,9 +8,9 @@
       >
         <div
           style="
-          background-position: top center;
+          background-position: center;
           background-repeat: no-repeat;
-          background-size: cover;
+          background-size: 100%;
           height:150px;
           background-image: url('{{ placeholder }}');
           "


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/788293/95554351-55319780-0a10-11eb-859e-e71360131134.png)

# After:
![image](https://user-images.githubusercontent.com/788293/95554385-65497700-0a10-11eb-911f-f7e401d4bbf0.png)
