### PR TITLE
Deleted absolute of projectlist__listing__url

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1528,6 +1528,10 @@ body {
             font-weight: 600;
             letter-spacing: 0;
             text-transform: uppercase;
+            position: absolute;
+            @media (max-width: 768px){
+              position: unset;
+            }
         }
     }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1524,7 +1524,6 @@ body {
             }
         }
         &__url {
-            position: absolute;
             bottom: 40px;
             font-weight: 600;
             letter-spacing: 0;


### PR DESCRIPTION

To fix an overlapping text issue in mobile, deleting position: absolute in the projectlist__listing__url style fixes the issue.

<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #733, this PR tackles:
- Overlapping of the url over the text in the project listing

Solution:
- Added a *media* class to *projectlist__listing__url* style class in *main.scss* for 768px screens and lower with *position: unset* to only remove *position: absolute* in small devices.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #733
