### PR TITLE
Update social link margin fixed

### DIFF
--- a/_includes/footer--simple.html
+++ b/_includes/footer--simple.html
@@ -1,6 +1,6 @@
 <footer class="footer pt-2 pt-md-5 pb-2 pb-md-5">
   <div class="container">
-    <div class="row mt-4 mt-md-0">
+    <div class="row mt-4 mt-md-0 justify-content-lg-between">
       <div class="footer-collaboration col-md-5 col-lg-4 py-2 px-3 p-md-0">
         <p class="d-block d-md-none mt-2 footer-collaboration-with small">
           {{ site.data.l10n.[active_lang].t.project_of }}</p>
@@ -25,12 +25,12 @@
           </div>
         </a>
       </div>
-      <div class="footer-social text-right">
+      <div class="footer-social text-right px-3 px-md-0">
         {% include social-icons.html social_items=site.data.social follow_us_text=t.follow_us %}
       </div>
     </div>
 
-    <ul class="footer-links">
+    <ul class="footer-links px-2 px-md-0">
       {% for link in site.data.footer_links %}
       {% assign link_content = link[1].[active_lang] %}
       <li><a href="{{ link_content.url }}">{{ t[link_content.title ] | default: link_content.title | capitalize }}</a></li>


### PR DESCRIPTION
Fixed the margin for the social links and adjusted the rest of the content on desktop view

<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #735, this PR tackles:

1. The social links in the footer had no margin

## Solution

I've added some padding for the social links as well as the normal links (below the social).
I've also changed the content spacing in desktop view since they were too close together.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #735 
