### PR TITLE
[#678] Detail page of comingsoon APIs shows API info

### DIFF
--- a/_layouts/api-details.html
+++ b/_layouts/api-details.html
@@ -26,4 +26,14 @@ lang: {{ site.lang }}
 
 {% assign swaggerProjects = filteredProjects | jsonify | escape %}
 
-{% include swagger.html swaggerUrl=page.openapi logo=page.contact.logo lang=active_lang l10n=l10n swaggerProjects=swaggerProjects %}
+{% unless page.comingsoon %}
+  {% include swagger.html swaggerUrl=page.openapi logo=page.contact.logo lang=active_lang l10n=l10n swaggerProjects=swaggerProjects %}
+{% else %}
+  <div class="container my-5">
+    <h1 class="d-inline-block">
+      {{ page.title }}
+      <span class="badge badge-pill badge-secondary align-top h5">{{ t.coming_soon }}</span>
+    </h1>
+    <h2 class="subtitle">{{ page.abstract }}</h2>
+  </div>
+{% endunless %}


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As suggested by @bfabio https://github.com/italia/developers.italia.it/issues/678#issuecomment-704068256, the PR makes the detail page of comingsoon APIs display API info and comingsoon badge instead of the error message "No API definition provided".

Result:
![image](https://user-images.githubusercontent.com/9085116/95904572-f8c7d280-0d97-11eb-86b6-72b47d746175.png)


## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #678
