### PR TITLE
added margin-bottom to .Pills .Pill in main.scss

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1788,6 +1788,7 @@ body {
         line-height: 1;
         text-transform: capitalize;
         font-weight: 600;
+        margin-bottom: 10px;
     }
 }
 


### PR DESCRIPTION
This fixes the issue https://github.com/italia/developers.italia.it/issues/734 with the incorrect margin in mobile view.
I have added a 10px margin-bottom to fix it.


## Description
As already mentioned in #734 , this PR tackles:
The added margin between the categories cloud. I added a bottom margin to main.scss


- [X ] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [X] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [X] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #734 

