### PR TITLE
[#708] Adds the alt attribute to the img tag to solve the a11y warning

### DIFF
--- a/_includes/github_team_members.html
+++ b/_includes/github_team_members.html
@@ -15,10 +15,9 @@
 			<div class="carousel-item {% if forloop.first %}active{%endif%}">
 				<ul class="list-unstyled">
 					{% endif %}
-
 					<li class="d-flex project__leaders__item mb-3">
 						<a href="{{member.html_url}}" title="{{member.login}}" target="_blank"><img width="50"
-								src="{{member.avatar_url}}&s=50"></a>
+								src="{{member.avatar_url}}&s=50" alt="{{member.name}}"></a>
 						<div class="ml-2 d-flex">
 							<a href="{{member.html_url}}" title="{{member.login}}" target="_blank"
 								class="align-self-center">{{member.name | default: member.login}}</a>


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #708], this PR tackles:
Adds the alt attribute to the img tag put the team member name as text

In particular, the ...

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #708 
