### PR TITLE
fix: move google analytics snippet from body to head

### DIFF
--- a/_includes/footer--simple.html
+++ b/_includes/footer--simple.html
@@ -43,5 +43,4 @@
 <script src="//localhost:8080/bundle.js"></script>
 {% endif %}
 
-{% if jekyll.environment == 'production' and site.google_analytics %} {% include google-analytics.html %} {% endif %}
 {% if jekyll.environment == 'production' and site.piwik %} {% include piwik.html %} {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,6 +38,8 @@
   <meta name="application-name" content="{{ site.title }}">
   <meta name="msapplication-config" content="{{ '/assets/icons/browserconfig.xml' | relative_url }}">
   <meta name="theme-color" content="{{ site.theme_color }}">
+  
+  {% if jekyll.environment == 'production' and site.google_analytics %} {% include google-analytics.html %} {% endif %}
 </head>
 
 <body class="layout-{{ page.layout }}">


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
<!--- Insert a title following the convention: [#ISSUE_NUMBER] where ISSUE_NUMBER is the number of the issue that this PR is going to solve. -->

## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #808 , this PR tackles:
* move GA snippet to the end of head tag.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [X] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [X] The documentation related to the proposed change has been updated accordingly (also comments in code).
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally?
- [X] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #808 
