### PR TITLE
fix: don't index PAs to Elasticsearch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -220,6 +220,10 @@ elasticsearch:
   custom_settings: _es_settings.yml
   custom_mappings: _es_mappings.yml
   ignore:
+    # Already indexed in the 'publiccodes' index.
     - /it/software/*
     - /en/software/*
-    - /it/bagnacavallo/
+
+    # Already indexed in the 'administrations' index.
+    - /it/pa/*
+    - /en/pa/*

--- a/assets/images/icon-type-unknown.svg
+++ b/assets/images/icon-type-unknown.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="17"
+   height="20"
+   viewBox="3 0 17 20"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="icon-type-unknown.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="27.812867"
+     inkscape:cx="-3.1379271"
+     inkscape:cy="10.912361"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <path
+     d="M 12.7,0 H 4.5 A 1.5,1.5 0 0 0 3,1.5 v 17 A 1.5,1.5 0 0 0 4.5,20 h 11 A 1.5,1.5 0 0 0 17,18.5 V 4.3 Z M 13,1.7 15.3,4 H 13.5 A 0.5,0.5 0 0 1 13,3.5 Z M 15.5,19 H 4.5 A 0.5,0.5 0 0 1 4,18.5 V 1.5 A 0.5,0.5 0 0 1 4.5,1 H 12 V 3.5 A 1.5,1.5 0 0 0 13.5,5 H 16 V 18.5 A 0.5,0.5 0 0 1 15.5,19 Z M 5.9999995,7 H 14 V 8.0000001 H 5.9999995 Z m 0,2.0000001 H 14 V 10 H 5.9999995 Z m 0,1.9999999 h 4 v 1 h -4 z"
+     id="path2"
+     inkscape:connector-curvature="0" />
+  <path
+     d="M -2,-2 H 22 V 22 H -2 Z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:none" />
+</svg>

--- a/assets/js/esDevelopersItaliaQuery.js
+++ b/assets/js/esDevelopersItaliaQuery.js
@@ -11,8 +11,8 @@ var DISE = {};
 // Categories of this search engine
 DISE.categories = {
   'unknown': {
-    'it': 'Misc',
-    'en': 'Misc'
+    'it': 'Pagina',
+    'en': 'Page'
   },
   'news': {
     'it': 'News',
@@ -1475,7 +1475,8 @@ esDevelopersItaliaAutocompleteAllQuery.prototype.getSuggestionDataSoftware = fun
 esDevelopersItaliaAutocompleteAllQuery.prototype.getSuggestionDataPost = function (post) {
   var value = $(this.config['inputSelector']).val();
   var name = post.title;
-  var category = DISE.categories[post.type || 'unknown'];
+  const post_type = post.type || 'unknown';
+  var category = DISE.categories[post_type];
 
   value = value.trim().split(' ');
   for (var i = 0; i < value.length; i++) {
@@ -1486,7 +1487,7 @@ esDevelopersItaliaAutocompleteAllQuery.prototype.getSuggestionDataPost = functio
     'name': name,
     'language': this.config['language'],
     'category': category[this.config['language']].toUpperCase(),
-    'categoryClass': ['category', 'icon', 'icon-type-' + post.type].join(' '),
+    'categoryClass': ['category', 'icon', `icon-type-${post_type}`].join(' '),
     'path': post.url
   };
 };

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -2053,6 +2053,11 @@ body {
             content: url('/assets/images/icon-type-news--gray.svg');
         }
     }
+    &unknown{
+        &:before {
+            content: url('/assets/images/icon-type-unknown.svg');
+        }
+    }
 }
 
 .list-item-sorting *[class*='icon-type'] {


### PR DESCRIPTION
Don't index PAs pages to Elasticsearch because they are already
included as 'administrations'.

Also rename 'misc' search result hits to a more user friendly 'page'.

Fix #664, fix #672.