### PR TITLE
chore: add Vercel configuration file

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "name": "Developers Italia",
+  "cleanUrls": true
+}


### PR DESCRIPTION
Set the site name and instruct Vercel to serve HTML with
their extension removed (to mimic Jekyll serve and GitHub pages).