### PR TITLE
chore: tell Vercel not to build the gh-pages branch

### DIFF
--- a/.vercel/ignore-gh-pages.sh
+++ b/.vercel/ignore-gh-pages.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Don't try to build the gh-pages branch.
+
+if [[ "$BRANCH" != "gh-pages" ]] ; then
+  # Proceed with the build
+  exit 1;
+else
+  # Don't build
+  exit 0;
+fi


### PR DESCRIPTION
Looks like Vercel "Ignored Build Step" doesn't support piping (yet?),
so we're forced to use an external script ("bash .vercel/ignore-gh-pages.sh").