### PR TITLE
[#687] Sticky sideblock for app page

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -2269,6 +2269,8 @@ body {
         background-color: white;
         box-shadow: 0 8px 24px 0 rgba(50,50,50,.15)!important;
         padding: 20px;
+        position: sticky;
+        top: 6.25rem;
 
         ul {
             list-style-type: none;


### PR DESCRIPTION
Changed sideblock to sticky
## Description
<!--- Describe in details the proposed mods -->
As already mentioned in #,687 this PR tackles:
* Keeps sideblock always in viewport 

In particular,
* Changed position to `sticky` at a top value of `100px`. This will keep the sideblock always at a fixed distance of 100px from top of the window instead of letting it scroll up of the view.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
- [x] I followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md)
- [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->
- Fixes #687 
