### PR TITLE
chore(ci): speed up pa11y run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ references:
         make include-npm-deps
         make bundle-install-deployment
         which rsync || sudo apt-get install rsync
+        sudo apt-get install gawk
 
   save_cache_yarn: &save_cache_yarn
     save_cache:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ github-import: bundle-install
 
 test:
 	npm run lint
-	npm run a11y
+	scripts/pa11y.sh
 	bundle exec htmlproofer ./_site --assume-extension --check-html --allow-hash-href --empty-alt-ignore --only-4xx --disable-external
 
 local:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "scripts": {
         "build": "webpack --config webpack.prod.js",
         "lint": "npx eslint _site/ --ext .json",
-        "a11y": "find _site -name '*.html' -exec grep -L 'http-equiv=\"refresh\"' {} \\; | xargs npx pa11y-ci",
         "deploy": "gh-pages -u 'Deploy Bot <no-reply@teamdigitale.governo.it>' -d _site"
     },
     "devDependencies": {

--- a/scripts/pa11y.sh
+++ b/scripts/pa11y.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+# Skip redirect pages
+find _site -name '*.html' -exec grep -L 'http-equiv="refresh"' {} \; | \
+
+# Speed up things and print just the first page in /api, /pa or /software,
+# so we don't check the same layout multiple times.
+awk '
+match($0, "/../(api|pa|software)/", m){
+  pattern = m[0]
+  if (seen[pattern]) {
+    next
+  } else {
+    seen[pattern] = 1
+  }
+}
+{ print }
+' | xargs npx pa11y-ci


### PR DESCRIPTION
Speed up Pa11y by running only once for pages in /pa, software
or /api.

If one page passes, others should as well because they are based on
the same layout. This also keeps the pipeline from getting slower
as more software is added.

Fix #836.