### PR TITLE
chore(ci): run danger just on pull_request_target.

### DIFF
--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request_target]
+on: [pull_request_target]
 
 name: Pull request to master
 jobs:


### PR DESCRIPTION
Run danger just on pull_request_target for now, that's
where we have the right token.