### PR TITLE
Remove moment.js from package.json

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -2,8 +2,6 @@
 
 import 'bootstrap';
 
-import moment from 'moment';
-
 import 'datatables.net';
 
 import './js/esQuery';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "handlebars": "^4.0.11",
         "handlebars-loader": "^1.7.1",
         "jquery": "^3.5.0",
-        "moment": "^2.27.0",
         "owl.carousel": "^2.3.4",
         "perfect-scrollbar": "^1.5.0",
         "photoswipe": "^4.1.3",


### PR DESCRIPTION
## Description

## This PR
Removes explicit import of moment.js
However, it will be included in the bundle because it is used by chart.js, but it doesn't seem to be a direct dependency of developers.italia

## Checklist

* [ x] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [ x] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ x] Have you successfully ran tests with your changes locally?
* [ x] Ready for review! :rocket:
