### PR TITLE
Security: upgrade prismjs to 1.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15583,9 +15583,9 @@
             }
         },
         "prismjs": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-            "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+            "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
             "requires": {
                 "clipboard": "^2.0.0"
             }
@@ -16356,6 +16356,16 @@
                 "hastscript": "^5.0.0",
                 "parse-entities": "^2.0.0",
                 "prismjs": "~1.21.0"
+            },
+            "dependencies": {
+                "prismjs": {
+                    "version": "1.21.0",
+                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+                    "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+                    "requires": {
+                        "clipboard": "^2.0.0"
+                    }
+                }
             }
         },
         "regenerate": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "owl.carousel": "^2.3.4",
         "perfect-scrollbar": "^1.5.0",
         "photoswipe": "^4.1.3",
+        "prismjs": "^1.23.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",


### PR DESCRIPTION
## Description

 Dependabot cannot update prismjs to a non-vulnerable version. This PR pins `prismjs` version to 1.23.0


## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [x] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Ready for review! :rocket:

