### PR TITLE
updated shibboleth proxy in SPID page

### DIFF
--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -196,7 +196,7 @@ SPID can be integrated in the websites of the Public Administration, but also on
 2. Use and contribute to the open source components available in [Developers Italia](https://github.com/italia?q=spid).
 3. Use a test identity provider such as[spid-saml-check](https://github.com/italia/spid-saml-check){:target="_blank"} or [spid-testenv2](https://github.com/italia/spid-testenv2){:target="_blank"} to simulate the authentication flow and verify that your implementation is correct.
 4. Get in touch with other developers at [Slack](https://slack.developers.italia.it/){:target="_blank"}.
-5. Follow the accreditation procedure [described here](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
+5. Follow the onboarding [described here](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
 6. If you have any further questions or are having problems with onboarding, please consult the [SPID HelpDesk](https://helpdesk.spid.gov.it/index.php?a=add) page.
 
 SPID is based on the SAML2 protocol, thus the integration can be done in several ways:

--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -124,8 +124,8 @@ resources:
       desc: Keycloak OIDC to SAML2 SPID Proxy
     - title: Proxy con Shibboleth
       icon: github
-      url: https://github.com/italia/spid-shibboleth-proxy-docker
-      desc: Docker image that enables a IAM proxy, based on Apache2 and Shibboleth
+      url: https://github.com/robertogallea/spid-idp-proxy-shibboleth
+      desc: SPID Proxy based on Shibboleth IDP and SP
     - title: IAM in Python
       url: https://github.com/italia/spid-sp-sapspid
       icon: github
@@ -197,6 +197,7 @@ SPID can be integrated in the websites of the Public Administration, but also on
 3. Use a test identity provider such as[spid-saml-check](https://github.com/italia/spid-saml-check){:target="_blank"} or [spid-testenv2](https://github.com/italia/spid-testenv2){:target="_blank"} to simulate the authentication flow and verify that your implementation is correct.
 4. Get in touch with other developers at [Slack](https://slack.developers.italia.it/){:target="_blank"}.
 5. Follow the accreditation procedure [described here](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
+6. If you have any further questions or are having problems with onboarding, please consult the [SPID HelpDesk](https://helpdesk.spid.gov.it/index.php?a=add) page.
 
 SPID is based on the SAML2 protocol, thus the integration can be done in several ways:
 

--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -196,8 +196,8 @@ SPID can be integrated in the websites of the Public Administration, but also on
 2. Use and contribute to the open source components available in [Developers Italia](https://github.com/italia?q=spid).
 3. Use a test identity provider such as[spid-saml-check](https://github.com/italia/spid-saml-check){:target="_blank"} or [spid-testenv2](https://github.com/italia/spid-testenv2){:target="_blank"} to simulate the authentication flow and verify that your implementation is correct.
 4. Get in touch with other developers at [Slack](https://slack.developers.italia.it/){:target="_blank"}.
-5. Follow the onboarding [described here](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
-6. If you have any further questions or are having problems with onboarding, please consult the [SPID HelpDesk](https://helpdesk.spid.gov.it/index.php?a=add) page.
+5. Follow the onboarding procedure [described here](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
+6. If you have any further questions or are having problems with onboarding procedure, please consult the [SPID HelpDesk](https://helpdesk.spid.gov.it/index.php?a=add) page.
 
 SPID is based on the SAML2 protocol, thus the integration can be done in several ways:
 

--- a/_platforms/it/spid.md
+++ b/_platforms/it/spid.md
@@ -128,8 +128,8 @@ resources:
       desc: Keycloak OIDC to SAML2 SPID Proxy
     - title: Proxy con Shibboleth
       icon: github
-      url: https://github.com/italia/spid-shibboleth-proxy-docker
-      desc: Immagine Docker per creare un proxy basato su Apache2 e Shibboleth
+      url: https://github.com/robertogallea/spid-idp-proxy-shibboleth
+      desc: Shibboleth IDP con possibilità di delegare l'autenticazione ad un IDP SPID
     - title: IAM in Python
       url: https://github.com/italia/spid-sp-sapspid
       icon: github
@@ -201,6 +201,7 @@ L'integrazione di SPID è consentita sia per i siti della Pubblica Amministrazio
 3. Usa un Identity Provider di test come [spid-saml-check](https://github.com/italia/spid-saml-check){:target="_blank"} oppure [spid-testenv2](https://github.com/italia/spid-testenv2){:target="_blank"} per simulare il flusso di autenticazione e verificare che la tua implementazione sia corretta.
 4. Entra in contatto con gli altri sviluppatori in [Slack](https://slack.developers.italia.it/){:target="_blank"}.
 5. Segui la procedura di accreditamento [descritta nel sito di AGID](https://www.spid.gov.it/come-diventare-fornitore-di-servizi-pubblici-e-privati-con-spid){:target="_blank"}.
+6. Se hai ulteriori domande o stai riscontrando problemi con la procedura di accreditamente consulta la pagina di servizio [SPID HelpDesk](https://helpdesk.spid.gov.it/index.php?a=add).
 
 SPID è basato sul protocollo SAML2, per configurarlo è possibile scegliere una tra le molteplici soluzioni disponibili:
 


### PR DESCRIPTION
## Description

* chore: older ShibProxy is in EOL, a new shibboleth spid proxy here
* added AgID SPID HelpDesk page

In particular, this shibboleth idp project is hosted to a third-party github repository