### PR TITLE
chore: use --trace in jekyll serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 	bundle exec htmlproofer ./_site --assume-extension --check-html --allow-hash-href --empty-alt-ignore --only-4xx --disable-external
 
 local:
-	npx webpack-dev-server --config webpack.dev.js --color --progress -d --host 0.0.0.0 | bundle exec jekyll serve --livereload --incremental --host=0.0.0.0
+	npx webpack-dev-server --config webpack.dev.js --color --progress -d --host 0.0.0.0 | bundle exec jekyll serve --livereload --incremental --host=0.0.0.0 --trace
 
 jekyll-build:
 	JEKYLL_ENV=production bundle exec jekyll build


### PR DESCRIPTION
Use --trace in jekyll serve so any errors are clearly printed when the
development environment is started.