### PR TITLE
feat: add new open issues pages

### DIFF
--- a/assets/js/github-issues.js
+++ b/assets/js/github-issues.js
@@ -82,6 +82,11 @@ $(document).ready(function () {
       },
     ],
     initComplete() {
+      // Get type from query param (useful to share links)
+      const urlParams = new URLSearchParams(window.location.search);
+      const typeParam = urlParams.get('type');
+      const platformParam = urlParams.get('platform');
+
       this.api()
         .column('project:name')
         .every(function () {
@@ -98,9 +103,11 @@ $(document).ready(function () {
             .sort()
             .each(function (d) {
               const title = d in projects_dictionary ? projects_dictionary[d] : d;
-              apps.push({ text: title, value: title });
+              apps.push({ text: title, value: d });
             });
           $github_projects_list.setOptionsToSelect(apps);
+          $github_projects_list_select.selectpicker('val', platformParam);
+          $github_projects_list_select.trigger('change', platformParam);
         });
       this.api()
         .column('language:name')
@@ -119,9 +126,6 @@ $(document).ready(function () {
         .column('type:name')
         .every(function () {
           const column = this;
-          // Get type from query param (useful to share links)
-          const urlParams = new URLSearchParams(window.location.search);
-          const typeParam = urlParams.get('type');
           column
             .data()
             .unique()

--- a/en/issues.md
+++ b/en/issues.md
@@ -1,0 +1,19 @@
+---
+title: Open issues
+subtitle: Open issues in the Developers Italia repositories
+lang: en
+ref:
+  it: /it/attivita
+layout: github-issues
+---
+
+Do you want to help us but you don't know what to do?
+
+Here's a list of issues from our GitHub organization
+[@italia](https://github.com/italia "Italia on Github")
+with the <span class="badge badge-secondary">help wanted</span> label.
+You can use the filters to find what activity could suit you best!
+
+{:.u-textWeight-400 .u-margin-top-l }
+
+## Open issues

--- a/it/attivita.md
+++ b/it/attivita.md
@@ -1,0 +1,21 @@
+---
+title: Attività aperte
+subtitle: Le attività aperte nei repo di Developers Italia
+lang: it
+ref:
+  en: /en/issues
+layout: github-issues
+---
+
+Hai voglia di aiutare ma non sai da dove cominciare?
+
+Tutto lo sviluppo è su GitHub
+[@italia](https://github.com/italia "Italia su Github") e
+i progetti sono tanti, così come le tecnologie che usano.
+Questa pagina raccoglie le attività aperte marcate con
+<span class="badge badge-secondary">help wanted</span>
+per trovare quello che ti può interessare con più facilità.
+
+{:.u-textWeight-400 .u-margin-top-l }
+
+## Le attività aperte


### PR DESCRIPTION
Add new open issues pages in both languages (/it/attivita, /en/issues)

Fix #970.