### PR TITLE
Fix/New content platform designersitalia

### DIFF
--- a/_platforms/it/designers.md
+++ b/_platforms/it/designers.md
@@ -1,10 +1,10 @@
 ---
 title: Designers Italia
-subtitle: Il Design System della Pubblica Amministrazione Italiana
+subtitle: Il design system della Pubblica Amministrazione italiana
 logo: /assets/images/logo-design@2x.png
 external_website: https://designers.italia.it
-payoff: Designers dalla parte dei cittadini
-description: "Designers Italia è il punto di riferimento per la progettazione dei servizi della Pubblica Amministrazione: linee guida, strumenti, un design system e una community di designer per favorire la collaborazione e promuovere il ruolo dello human-centered design nello sviluppo dei servizi pubblici."
+payoff: Per semplificare la vita dei cittadini
+description: "Progettiamo insieme alle Pubbliche Amministrazioni servizi digitali di qualità per semplificare la vita dei cittadini. Designers Italia è il punto di riferimento per la progettazione dei servizi pubblici digitali: modelli, kit e guide per facilitare processi di design centrati sui bisogni dei cittadini"
 lang: it
 ref:
   en: /en/designers
@@ -14,91 +14,133 @@ comingsoon: false
 layout: platform
 github_team: design
 socials:
-  -
-    name: twitter
+  - name: twitter
     icon: twitter
     link: //twitter.com/DesignersITA
-  -
-    name: medium
+  - name: medium
     icon: medium
     link: //medium.com/designers-italia
+resources:
+  - UI Kit:
+    - title: UI Kit su Designers Italia
+      desc: Progetta l’interfaccia di un servizio con uno stile grafico semplice e coerente
+      url: https://designers.italia.it/kit/ui-kit/
+      icon: designers-italia
+    - title: Repository UI Kit
+      url: https://github.com/italia/design-ui-kit
+      desc: "È disponibile come file Sketch italia UI Kit 2.0.sketch, utilizzabile anche attraverso la funzione \"aggiungi come libreria\" di Sketch o importabile su Figma."
+      icon: github
+    - title: Anteprima UI Kit su Invision
+      desc: Se vuoi vedere tutti i componenti prima di scaricarli
+      url: https://invis.io/RJFGS2UC3HS
+      icon: pencil
+  - Web Development Kit:
+    - title: Web Development Kit su Designers Italia
+      desc: Costruisci siti, applicazioni e servizi web in assoluta semplicità
+      url: https://designers.italia.it/kit/web-development-kit/
+      icon: designers-italia
+    - title: Repository Bootstrap Italia
+      desc: "La libreria Bootstrap Italia è il modo più semplice e sicuro per costruire interfacce web moderne, inclusive e semplici da mantenere."      
+      url: https://github.com/italia/bootstrap-italia/
+      icon: github
+    - title: Documentazione Boostrap Italia
+      url: https://italia.github.io/bootstrap-italia/
+      icon: file
+    - title: Repository React Design Kit
+      desc: "Un set di componenti open-source per React, costruito sulle basi dello UI Kit e della libreria Bootstrap Italia"
+      url: https://github.com/italia/design-react-kit
+      icon: github
+    - title: Documentazione (storybook) React Design Kit
+      url: https://italia.github.io/design-react-kit/
+      icon: file
+  - Il sito web di un Comune:
+    - title: Il sito web di un Comune su Designers Italia
+      desc: "Modello di sito web e template grafico per i siti comunali, gratis e a disposizione di tutti"
+      url: https://designers.italia.it/kit/comuni/
+      icon: designers-italia
+    - title: Template HTML per il sito del Comune
+      url: https://github.com/italia/design-comuni-pagine-statiche
+      icon: github
+    - title: Repository completa del progetto sito web per i Comuni
+      url: https://github.com/italia/design-comuni-prototipi
+      icon: github
+    - title: Documentazione del progetto sito web per i Comuni
+      url: https://docs.italia.it/italia/designers-italia/design-comuni-docs/
+      icon: file
+  - Il sito web di una scuola:
+    - title: Il sito web di una scuola su Designers Italia
+      desc: "Modello di sito web e template CMS per i siti scolastici, gratis e a disposizione di tutti"
+      url: https://designers.italia.it/kit/scuole/
+      icon: designers-italia
+    - title: Tema Wordpress per il sito web della scuola
+      url: https://github.com/italia/design-scuole-wordpress-theme
+      icon: github
+    - title: Template HTML per il sito web della scuola
+      url: https://github.com/italia/design-scuole-pagine-statiche/
+      icon: github
+    - title: Documentazione del progetto sito web per le scuole
+      url: https://docs.italia.it/italia/designers-italia/design-scuole-docs/
+      icon: file
 
 redirect_from:
   - /it/design
 ---
 
-## Intro
+## Il digitale a misura di cittadino
 
 In questa pagina presentiamo il *design system* realizzato per la Pubblica Amministrazione italiana e gli strumenti di Designers Italia a disposizione degli sviluppatori.
 
-L’obiettivo è fornire dei kit (documenti, guide, o software) che facciano risparmiare tempo e denaro alla Pubblica Amministrazione e che costituiscano una solida base di partenza per la progettazione e lo sviluppo di app e siti web moderni, inclusivi e manutenibili. Alcuni di questi progetti sono già attivi, altri sono invece previsti dalla [roadmap](https://designers.italia.it/roadmap/){:target="_blank"}. Per restare aggiornati sull’evoluzione dei progetti consigliamo di iscriversi alla [newsletter di Designers Italia](https://designers.italia.it/){:target="_blank"}.
+L’obiettivo è aiutare la Pubblica Amministrazione a risparmiare tempo e risorse, grazie a una **serie di strumenti per la progettazione e lo sviluppo di siti e servizi pubblici digitali** a misura di cittadino, che possano essere allo stesso tempo moderni, efficaci, inclusivi e facilmente manutenibili.
 
 Il sito [designers.italia.it](https://designers.italia.it/){:target="_blank"} contiene:
 
-* I riferimenti alla versione corrente delle [Linee Guida di Design](https://designers.italia.it/guide/){:target="_blank"}
-* Una serie di [kit per il design dei servizi della Pubblica Amministrazione](https://designers.italia.it/kit/){:target="_blank"}
-* Il [blog](https://designers.italia.it/blog/){:target="_blank"} con case histories di utilizzo dei kit
+* i riferimenti alla versione corrente delle [Linee Guida di Design](https://designers.italia.it/guide/){:target="_blank"};
+* una serie di [kit per il design dei servizi pubblici digitali della Pubblica Amministrazione](https://designers.italia.it/kit/){:target="_blank"};
+* il collegamento alla piattaforma [Medium di Designers Italia](https://designers.italia.it/blog/){:target="_blank"} che ospita casi d'uso e applicazioni di successo del *design system* per la Pubblica Amministrazione.
 
-Il codice sorgente del sito stesso si trova in un [repository GitHub](https://github.com/italia/designers.italia.it){:target="_blank"} aperto ad ogni tipo di contributo.
+Il codice sorgente del sito si trova in un [repository GitHub](https://github.com/italia/designers.italia.it){:target="_blank"} aperto a ogni tipo di contributo.
 
-## UI Kit
-Lo UI Kit è un set di componenti visive già pronte per assemblare l’interfaccia di un sito o di un app, seguendo le linee guida per i servizi digitali della Pubblica Amministrazione. Il Kit è costruito con Sketch e definito in maniera aperta e collaborativa su GitHub insieme alla community dei designer. Lo UI Kit è il punto di riferimento per i componenti e i pattern di UI destinati ad essere implementati con l'utilizzo dei Web Development Kit, mostrati di seguito.
+## UI kit
+Lo UI kit è fatto di **componenti visive già pronte** per assemblare l’interfaccia di un sito o di un app, seguendo le linee guida per i servizi digitali della Pubblica Amministrazione e le migliori buone pratiche di design più diffuse nel panorama nazionale e internazionale.
 
-* [Introduzione allo UI Kit](https://designers.italia.it/kit/ui-kit/){:target="_blank"}
-* [Tutti i componenti e i pattern dello UI Kit](https://invis.io/RJFGS2UC3HS){:target="_blank"}
-* [Repository GitHub](https://github.com/italia/design-ui-kit){:target="_blank"}
+Il kit è costruito con Sketch e **definito in maniera aperta e collaborativa su GitHub** insieme alla *community* dei designer. Lo UI kit è il punto di riferimento per i componenti e i *pattern* di interfaccia utente destinati ad essere implementati con l'utilizzo dei kit di sviluppo web (Web Development Kit), mostrati di seguito.
 
-Molti progetti della Pubblica Amministrazione stanno già utilizzando lo UI Kit per definire le proprie interfacce, tra cui i modelli per i [siti dei comuni](https://github.com/italia/design-comuni-prototipi){:target="_blank"} e i [siti delle scuole](https://github.com/italia/design-scuole-prototipi){:target="_blank"}.
+* [Introduzione allo UI Kit](https://designers.italia.it/kit/ui-kit/){:target="_blank"};
+* [tutti i componenti e i pattern dello UI Kit](https://invis.io/RJFGS2UC3HS){:target="_blank"};
+* [repository GitHub](https://github.com/italia/design-ui-kit){:target="_blank"}.
+
+Sono sempre più in crescita le Pubblica Amministrazioni che stanno utilizzando lo UI kit per definire le proprie interfacce, tra le quali **un posto di assoluta rilevanza** spetta ai modelli per i [siti dei Comuni](https://github.com/italia/design-comuni-prototipi){:target="_blank"} e per i [siti delle scuole](https://github.com/italia/design-scuole-prototipi){:target="_blank"}.
 
 Per domande e discussioni sullo UI Kit, sullo [Slack di Developers Italia](https://slack.developers.italia.it/){:target="_blank"} è disponibile e aperto a tutti il canale [#design-ui](https://developersitalia.slack.com/messages/C9N62GX8E/){:target="_blank"}.
 
 ## Web Development Kit
-I [Web Development Kit](https://designers.italia.it/kit/web-development-kit/){:target="_blank"} sono un insieme di strumenti per lo sviluppo front end di siti e applicazioni web. Sono librerie HTML, CSS e Javascript che permettono di realizzare siti conformi alle Linee Guida di Design e realizzano in codice quanto previsto dallo UI Kit. Allo stato attuale, il kit per lo sviluppo web più stabile, aggiornato e maturo è Bootstrap Italia, basato sulla libreria open-source Bootstrap 4.
+I [Web Development Kit](https://designers.italia.it/kit/web-development-kit/){:target="_blank"} sono un insieme di strumenti per lo sviluppo front end di siti e applicazioni web. Sono librerie HTML, CSS e Javascript che permettono di **realizzare siti conformi alle Linee Guida di Design** e realizzano in codice quanto previsto dallo UI kit. Allo stato attuale, il kit per lo sviluppo web più stabile, aggiornato e maturo è Bootstrap Italia, basato sulla libreria *open source* Bootstrap 4.
 
 ### Bootstrap Italia
 
-Il kit basato su Bootstrap 4 è il punto di riferimento per lo sviluppo dei progetti della Pubblica Amministrazione. Lo scopo principale è mettere a disposizione della comunità di sviluppatori, coerentemente con le [Linee Guida di Design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/){:target="_blank"}, la sintassi, gli strumenti, il parco di plugin e le convenzioni tipiche di uno strumento da molti già conosciuto ed utilizzato, quale appunto [Bootstrap 4](https://getbootstrap.com/){:target="_blank"}.
+Il kit basato su Bootstrap 4 è il punto di riferimento per lo sviluppo dei progetti della Pubblica Amministrazione. Lo scopo principale è **mettere a disposizione della comunità di sviluppatori**, in coerenza con le [Linee Guida di Design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/){:target="_blank"}, la sintassi, gli strumenti, il parco di plugin e le convenzioni tipiche di uno strumento già conosciuto e utilizzato, quale appunto [Bootstrap 4](https://getbootstrap.com/){:target="_blank"}.
 
-* [Documentazione di Bootstrap Italia](https://italia.github.io/bootstrap-italia/){:target="_blank"}
-* [Repository GitHub](https://github.com/italia/bootstrap-italia){:target="_blank"}
-* [Esempio di template base da cui partire](https://italia.github.io/bootstrap-italia/docs/esempi/template-vuoto/){:target="_blank"}
+* [Documentazione di Bootstrap Italia](https://italia.github.io/bootstrap-italia/){:target="_blank"};
+* [repository GitHub](https://github.com/italia/bootstrap-italia){:target="_blank"};
+* [esempio di template base da cui partire](https://italia.github.io/bootstrap-italia/docs/esempi/template-vuoto/){:target="_blank"}.
 
-Bootstrap Italia è già utilizzato su alcuni progetti con successo, come il [prototipo del sito del Comune di Cagliari](https://italia.github.io/design-comuni-prototipi/){:target="_blank"} e il sito [Docs Italia](https://docs.italia.it/){:target="_blank"}.
-
-Altri progetti, come i siti per le scuole e i temi per i principali CMS (Wordpress, Drupal, Joomla, Plone, Entando, ecc.) e generatori di siti statici (Hugo, Jekyll, ecc.), sono in fase di valutazione o pianificazione. L'unico attualmente disponibile, per quanto ancora in lavorazione, è il [Tema Wordpress](https://github.com/italia/design-wordpress-theme/){:target="_blank"}.
-
-Per segnalare un sito, una app o un tema realizzato con Bootstrap Italia, [puoi aprire una issue](https://github.com/italia/bootstrap-italia/issues){:target="_blank"} sul repository di Bootstrap Italia o [scrivere un post sul forum](https://forum.italia.it/c/design/esempi-linee-guida){:target="_blank"}!
-
-### Web Toolkit
-
-Il Web Toolkit è stato il primo progetto concreto per aiutare la realizzazione di siti web per la PA; esso è già usato da molti siti web, in particolare alcuni comuni e ministeri. I feedback ricevuti sull’utilizzo del Web Toolkit da parte di enti e fornitori hanno contribuito alla definizione e alla creazione del kit di riferimento Bootstrap Italia.
-
-Per questo, il Web Toolkit non è più oggetto di significativi aggiornamenti dal 2017.
-
-* [Documentazione del Web Toolkit](https://italia.github.io/design-web-toolkit/){:target="_blank"}
-* [Repository GitHub](https://github.com/italia/design-web-toolkit){:target="_blank"}
+**Contribuisci alla crescita del design system:** per segnalare un sito, una app o un tema realizzato con Bootstrap Italia, [puoi aprire una issue](https://github.com/italia/bootstrap-italia/issues){:target="_blank"} sul repository di Bootstrap Italia o [scrivere un post sul forum](https://forum.italia.it/c/design/esempi-linee-guida){:target="_blank"}!
 
 ### Design React Kit
 
-Il progetto ha come obiettivo quello di costruire un set di componenti ed un layer di presentazione comune basato su [React](https://github.com/facebook/react/){:target="_blank"}. Il focus del progetto sono state, almeno in questa fase iniziale, le web app e/o le applicazioni mobile ibride basate su [React Native](https://facebook.github.io/react-native/){:target="_blank"}. Il React Kit non è ancora completo in quanto molti dei componenti presenti su Bootstrap Italia non sono ancora stati convertiti per l’utilizzo come componenti React.
+Il progetto ha come obiettivo quello di costruire un set di componenti ed un layer di presentazione comune basato su [React](https://github.com/facebook/react/){:target="_blank"}. Il focus del progetto sono le web app e/o le applicazioni mobile ibride basate su [React Native](https://facebook.github.io/react-native/){:target="_blank"}. Il React Kit non è completo in quanto alcuni dei componenti presenti su Bootstrap Italia non sono ancora stati implementati.
 
-* [Documentazione del Design React Kit](https://italia.github.io/design-react-kit/){:target="_blank"}
-* [Repository GitHub](https://github.com/italia/design-react-kit){:target="_blank"}
+* [Documentazione del Design React Kit](https://italia.github.io/design-react-kit/){:target="_blank"};
+* [repository GitHub](https://github.com/italia/design-react-kit){:target="_blank"}.
 
-### Design Angular Kit
+## Tutti i design kit per la progettazione
 
-Il progetto ha come obiettivo quello di costruire un set di componenti ed un layer di presentazione comune basato su [Angular](https://angular.io/){:target="_blank"}. Il kit non è ancora completo.
+La realizzazione dell'interfaccia e dello sviluppo web sono soltanto una parte del processo di definizione di un servizio digitale. Designers Italia mette a disposizione kit e modelli che coprono tutte le fasi di progettazione di un servizio, dall'organizzazione del progetto alla comprensione del contesto, dalla progettazione alla realizzazione e validazione delle soluzioni con gli utenti.
 
-* [Documentazione del Design Angular Kit](https://italia.github.io/design-angular-kit/){:target="_blank"}
-* [Repository GitHub](https://github.com/italia/design-angular-kit){:target="_blank"}
+Per maggiori informazioni, puoi iniziare dalla pagina dei [kit sul sito di Designers Italia](https://designers.italia.it/kit/){:target="_blank"}.
 
-Le contribuzioni sui kit sono molto importanti, per cui se pensi di poter dare una mano con feedback, informazioni utili, segnalazioni di bug o codice, fatti avanti!
+## Canali
 
-Per domande e discussioni sui Web Development Kit, sullo [Slack di Developers Italia](https://slack.developers.italia.it/){:target="_blank"} è disponibile il canale [#design-devel](https://developersitalia.slack.com/messages/C7VPAUVB3/){:target="_blank"}.
+<a class="btn btn-primary" href="https://forum.italia.it/c/design" target="_blank"><i class="it-horn" /> Entra nel forum</a>
 
-## Altri kit utili per la progettazione
-
-Lo sviluppo web è soltanto parte del ciclo di lavorazione di un servizio secondo le Linee Guida di Design. Designers Italia mette a disposizione Kit che coprono tutto il ciclo di progettazione di un servizio, dalla ricerca all'architettura dell'informazione, passando per i test con gli utenti. Per maggiori informazioni, puoi iniziare dalla pagina dei [Kit sul sito di Designers Italia](https://designers.italia.it/kit/){:target="_blank"}.
-
-Per domande e discussioni su questi kit di design, sullo [Slack di Developers Italia](https://slack.developers.italia.it/){:target="_blank"} è disponibile il canale [#design-service](https://developersitalia.slack.com/messages/C9HKFKU9J/){:target="_blank"}.
-
+Dialoga sullo [Slack di Developers Italia](https://slack.developers.italia.it/){:target="_blank"}: sono disponibili diversi canali che iniziano con "#design-", in particolare segnaliamo: [#design-service](https://developersitalia.slack.com/messages/C9HKFKU9J/){:target="_blank"}, [#design-ui-kit](https://developersitalia.slack.com/archives/C9N62GX8E), [#design-dev](https://developersitalia.slack.com/archives/C7VPAUVB3), [#design-siti-dei-comuni](https://developersitalia.slack.com/archives/CME9AD8NN) e [#design-siti-scuole](https://developersitalia.slack.com/archives/CQ7J0KANT)


### PR DESCRIPTION
## Description

This PR tackles:

* new contents for the Designers Italia platform page

In particular, I added the "Risorse" block using a tab approach to showcase direct links to repositories and documentations of resources like UI Kit, Bootstrap Italia, React Design Kit, ... 

## Checklist

* [ ] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->

Fixes #
