### PR TITLE
mibact->mic

### DIFF
--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -100,5 +100,5 @@
     logo: /assets/images/api/logo-ministero-cultura.svg
   tags: [data]
   language: [it]
-  slug: mibact-data-sparql
+  slug: mic-data-sparql
 


### PR DESCRIPTION
cambio da mibact a mic per l'URL in modo da riflettere la nuova sigla