### PR TITLE
fix: make alphabetical order work in search engine

### DIFF
--- a/assets/js/api/elasticSearchUtils.js
+++ b/assets/js/api/elasticSearchUtils.js
@@ -18,11 +18,26 @@ export const buildFilter = (filters) => {
 
 export const buildSort = (sortBy) => {
   if (sortBy === ALPHABETICAL) {
-    return [
-      {
-        'publiccode.description.it.localizedName.keyword': { order: 'asc', unmapped_type: 'keyword' },
+    return {
+      _script: {
+        type: 'string',
+        order: 'asc',
+        script: {
+          lang: 'painless',
+          source: `
+             if (
+                 doc['publiccode.description.it.localisedName.keyword'].size() != 0
+                 && !doc['publiccode.description.it.localisedName.keyword'].empty
+                ) {
+               return doc['publiccode.description.it.localisedName.keyword'].value
+             }
+             else {
+               return doc['publiccode.name.keyword'].value
+             }
+           `,
+        },
       },
-    ];
+    };
   }
   if (sortBy === VITALITY) {
     return [

--- a/assets/js/api/elasticSearchUtils.js
+++ b/assets/js/api/elasticSearchUtils.js
@@ -1,4 +1,5 @@
 import { ALPHABETICAL, RELEASE_DATE, VITALITY } from '../utils/constants.js';
+import { lang } from '../utils/l10n.js';
 
 export const buildFilter = (filters) => {
   let { intendedAudiences, categories, developmentStatuses } = filters;
@@ -26,10 +27,10 @@ export const buildSort = (sortBy) => {
           lang: 'painless',
           source: `
              if (
-                 doc['publiccode.description.it.localisedName.keyword'].size() != 0
-                 && !doc['publiccode.description.it.localisedName.keyword'].empty
+                 doc['publiccode.description.${lang}.localisedName.keyword'].size() != 0
+                 && !doc['publiccode.description.${lang}.localisedName.keyword'].empty
                 ) {
-               return doc['publiccode.description.it.localisedName.keyword'].value
+               return doc['publiccode.description.${lang}.localisedName.keyword'].value
              }
              else {
                return doc['publiccode.name.keyword'].value


### PR DESCRIPTION
Use Elastic's scripting to sort alphabetically and provide a fallback if
localizedName for the current language is not present.
    
I don't know if that's the smartest way to do it, but it's A solution.

Fix #882