### PR TITLE
chore: make Vercel stop commenting on PRs and commits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
   "name": "Developers Italia",
-  "cleanUrls": true
+  "cleanUrls": true,
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
Vercel comments by default on PRs and that makes GitHub send a
notication right away to the submitter, which is not really useful.