### PR TITLE
feat: add visual hint when the support of a software has ended

### DIFF
--- a/_data/l10n.yml
+++ b/_data/l10n.yml
@@ -253,6 +253,7 @@ it:
       detailed_info: Informazioni di dettaglio
       maintainance_type: Tipo di manutenzione
       contract_with: Contratto con
+      contract_warning: Supporto software terminato
       last_release: Ultimo rilascio
       license: Licenza
       page: pagina
@@ -567,6 +568,7 @@ en:
       detailed_info: detailed information
       maintainance_type: Type of maintenance
       contract_with: Contract with
+      contract_warning: Software support ended
       last_release: Last release
       license: License
       page: page

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -443,7 +443,7 @@ layout: default
                     {% assign contractor_date = contractor.until | date: '%s' %}
                     {% if today_date > contractor_date %}
                     <svg class="icon icon-sm icon-warning" role="img" aria-labelledby="software-support-ended">
-                      <title id="software-support-ended">Software support ended</title>
+                      <title id="software-support-ended">{{ t.software.contract_warning }}</title>
                       <use xlink:href="/assets/svg/sprite.svg#it-warning-circle"></use>
                     </svg>
                     {% endif %}


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
This PR tackles:

* Add a visual hint to make clear when the support of a software has ended.

## Fixes
<!-- Please insert the issue numbers after the # symbol -->

Fixes #934
