### PR TITLE
chore: spid wordpress SDK updated

### DIFF
--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -79,7 +79,7 @@ resources:
       desc: Native library for integrating SPID in PHP applications
     - title: SDK for Wordpress
       icon: github
-      url: https://github.com/italia/spid-wordpress
+      url: https://github.com/WPGov/wp-spid-italia
       desc: Native library for integrating SPID in Wordpress (PHP) applications
     - title: SDK for Laravel
       icon: github

--- a/_platforms/it/spid.md
+++ b/_platforms/it/spid.md
@@ -87,7 +87,7 @@ resources:
       desc: Libreria nativa per l'integrazione di SPID in applicazioni mobile iOS
     - title: SDK per Wordpress
       icon: github
-      url: https://github.com/italia/spid-wordpress
+      url: https://github.com/WPGov/wp-spid-italia
       desc: Plugin nativo per l'integrazione del login con SPID in siti Wordpress (PHP)
     - title: SDK per Laravel
       icon: github


### PR DESCRIPTION
Wordpress SDK has been updated, following this roadmap

https://github.com/italia/spid-wordpress/issues/18#issuecomment-952709954
