### PR TITLE
feat: sort software by release_date when no search term is available

### DIFF
--- a/assets/js/components/Catalogue/CatalogueContainer.js
+++ b/assets/js/components/Catalogue/CatalogueContainer.js
@@ -10,7 +10,7 @@ import {
   initialSortBy,
   initialType,
 } from '../../utils/urlSearchParams.js';
-import { ALL_CATALOGUE, RELEVANCE } from '../../utils/constants.js';
+import { ALL_CATALOGUE, RELEVANCE, RELEASE_DATE } from '../../utils/constants.js';
 import { CatalogueView } from './CatalogueView.js';
 import { CatalogueFiltersContainer } from './CatalogueFiltersContainer.js';
 
@@ -25,6 +25,8 @@ const useStyle = createUseStyles({
 export const CatalogueContainer = () => {
   const classes = useStyle();
 
+  const defaultSortBy = initialSearchValue ? RELEVANCE : RELEASE_DATE;
+
   return (
     <SearchProvider
       initialCategories={initialCategories}
@@ -32,7 +34,7 @@ export const CatalogueContainer = () => {
       initialPage={Number(initialPage)}
       initialIntendedAudiences={initialIntendedAudiences}
       initialSearchValue={initialSearchValue}
-      initialSortBy={initialSortBy ?? RELEVANCE}
+      initialSortBy={initialSortBy ?? defaultSortBy}
       initialType={initialType ?? ALL_CATALOGUE}
       syncStateWithQueryString={true}
     >

--- a/assets/js/components/Catalogue/CatalogueSort.js
+++ b/assets/js/components/Catalogue/CatalogueSort.js
@@ -1,15 +1,18 @@
 import React, { useContext } from 'react';
 import { l10NLabels } from '../../utils/l10n.js';
 import { initialSortBy } from '../../utils/urlSearchParams.js';
-import { searchContextDispatch, setSortBy } from '../../contexts/searchContext.js';
+import { searchContextState, searchContextDispatch, setSortBy } from '../../contexts/searchContext.js';
+import { RELEVANCE } from '../../utils/constants.js';
 
 export const CatalogueSort = React.memo(() => {
+  const { searchValue, sortBy } = useContext(searchContextState);
   const dispatch = useContext(searchContextDispatch);
+  const showRelevance = sortBy === RELEVANCE || searchValue;
   return (
     <div className="d-flex flex-wrap justify-content-end align-items-center">
       <label className="mb-0 pr-2">{l10NLabels.software.sort_by}</label>
       <select onChange={(e) => dispatch(setSortBy(e.target.value))} defaultValue={initialSortBy}>
-        <option value="relevance">{l10NLabels.software.sort_by_relevance}</option>
+        {showRelevance ? <option value="relevance">{l10NLabels.software.sort_by_relevance}</option> : null}
         <option value="release_date">{l10NLabels.software.sort_by_release_date}</option>
         <option value="vitality">{l10NLabels.software.sort_by_vitality}</option>
         <option value="name">{l10NLabels.software.sort_by_alphabetic}</option>

--- a/assets/js/components/Catalogue/CatalogueSort.test.js
+++ b/assets/js/components/Catalogue/CatalogueSort.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SearchProvider } from '../../contexts/searchContext';
+import { RELEASE_DATE } from '../../utils/constants';
+import { CatalogueSort } from './CatalogueSort';
+
+jest.mock('../../utils/l10n.js');
+
+describe('CatalogueSort', () => {
+  describe('when the search value is not available', () => {
+    it('should hide the relevance filter', () => {
+      const screen = render(
+        <SearchProvider initialSortBy={RELEASE_DATE} initialSearchValue={null}>
+          <CatalogueSort />
+        </SearchProvider>
+      );
+      expect(
+        screen.queryByRole('option', {
+          name: 'Rilevanza',
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe('when the search value is available', () => {
+    it('should show the relevance filter', () => {
+      const screen = render(
+        <SearchProvider initialSortBy={RELEASE_DATE} initialSearchValue={'some search'}>
+          <CatalogueSort />
+        </SearchProvider>
+      );
+      expect(
+        screen.getByRole('option', {
+          name: 'Rilevanza',
+        })
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
This PR improves the browsing experience when no explicit search term has been submitted

In particular, the sorting criteria is being defaulted to "release date"

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [x] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [x] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->

Fixes #1022 
