### PR TITLE
chore: update Italian and English legal notices

### DIFF
--- a/en/legal-notice.md
+++ b/en/legal-notice.md
@@ -1,88 +1,104 @@
 ---
-title: Legal Notice 
+title: Legal Notice
 lang: en
 ref:
   it: /it/note-legali
 layout: internal-long
 ---
 
+La Presidenza del Consiglio dei Ministri - Dipartimento per la trasformazione
+digitale, con sede in Largo Pietro di Brazzà 86, 00186 Roma, ha realizzato
+questo sito con lo scopo di contribuire alla crescita e al coordinamento di
+una community interessata allo sviluppo di codice strumentale al funzionamento
+dei servizi online della pubblica amministrazione.
 
-[https://developers.italia.it](https://developers.italia.it) is a site that
-aims to contribute to the growth and coordination of a community of developers
-interested in developing instrumental code for the operation of online public
-administration services. The site is managed by the Agency for Digital Italy.
+## Licenza dei contenuti
 
-In some cases (discussion forums), in order to access the contents and / or use
-the Services it may be necessary to use credentials issued by the providers of
-other services (e.g., github or google) or register, requesting the
-attribution of new credentials. The user acknowledges that the Agency,
-throughout the entire relationship, will identify them as the owner of their
-rights and duties solely on the basis of the digital identity assigned to them
-and represented by the credentials (user ID/email and password) that they
-have indicated and / or chosen to use. The user therefore undertakes to keep
-these credentials and to immediately report to the Agency - if they had chosen
-to register directly on the Site - to the address
-[protocollo@pec.agid.gov.it](mailto:protocollo@pec.agid.gov.it) the possible
-loss of exclusive control over them, taking note of the fact that, in the
-absence of such notification and up to the moment of its reception, they will
-be responsible for every action and conduct put in place using such credentials
-(e.g., publication of an online content, request for a Service, etc.) and will
-not be able in any way to dispute the use of the services or access to the
-contents connected to the use of the aforementioned credentials.
+In applicazione del principio open by default ai sensi dell’articolo 52 del
+decreto legislativo 7 marzo 2005, n. 82 (CAD) e salvo dove diversamente
+specificato (compresi i contenuti incorporati di terzi), i dati, i documenti e
+le informazioni pubblicati sul sito sono rilasciati con licenza
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode.it).
 
-If the user, through certain services available on the website (e.g.,
-discussion forum), can proceed with the publication, dissemination or
-communication of content, they undertake not to publish, spread or communicate
-exclusively unsuitable contents violating law and/or any rights of third
-parties. In this case, moreover, the user declares and guarantees to have all
-the rights necessary for the publication of the contents (texts, images,
-photographs and/or pictures, videos, audiovisual material), having, if
-necessary, previously obtained, where necessary, all the consents and
-disclaimers provided for by current regulations, with particular - but not
-exclusive - reference to the law on copyright and on protection of privacy. The
-User hereby undertakes to guarantee to keep the Agency for Digital Italy safe
-from any claim, including compensation, proposed and/or deriving, directly or
-indirectly, from the use by the same user of the Services and/or the
-publication of any content. For the purposes of this indemnity, any conduct put
-in place using the credentials assigned to the latter will be considered
-imputable to the user, unless the loss to the society is communicated prior to
-the aforementioned conduct. It is understood that the Agency for Digital Italy
-reserves the right to remove at any time any content published by the user
-through the services in relation to the reporting of an alleged violation of
-third party rights or in any case at its own unquestionable judgment. The User
-grants the Agency for Digital Italy the right and license, not subject to any
-compensation - and as such completely free - and not exclusive, to use, adapt,
-publish, distribute, reproduce and execute without territorial and / or time of
-publication limitations the content sent and published by the User through the
-services. The foregoing provisions relating to the publication of content
-through the site do not apply to the publication of source code through the
-Github service referred to by the site. This publication remains subject to the
-terms of use accepted by users when accessing the relevant discussion platform.
+Gli utenti sono quindi liberi di condividere (riprodurre, distribuire,
+comunicare al pubblico, esporre in pubblico, rappresentare, eseguire e recitare
+questo materiale con qualsiasi mezzo e formato) e modificare (trasformare il
+materiale e utilizzarlo per opere derivate) per qualsiasi fine, anche
+commerciale con il solo onere di attribuzione, senza apporre restrizioni
+aggiuntive.
 
-The ownership of all documents and content (texts, presentations, images,
-photos, videos, etc.) belongs to the Agency for Digital Italy. The display,
-download and any use of the data published on the Site implies acceptance of
-these legal notes and the conditions of the license with which they are
-published. Unless otherwise indicated, the contents published on this site are
-made available with a CC – BY 3.0 license, the full text of which is available
-at the following address:
-[https://creativecommons.org/licenses/by/3.0/it/legalcode](https://creativecommons.org/licenses/by/3.0/it/legalcode).
-This means that, unless otherwise specified, the contents of this site are
-freely distributable and reusable, provided that the source is always cited and
-- where possible - the web address of the original page is reported. The source
-code of the Site is instead available
-[on the Github platform ](https://github.com/italia/developers.italia.it) and,
-therefore, reusable within the limits of the related license. The Agency for
-Digital Italy is constantly striving to ensure the quality of the information
-published on the site, as well as their integrity, updating, completeness,
-promptness, simplicity of reference and accessibility. For any report or
-suggestion you can write to the address
-[protocollo@pec.agid.gov.it](mailto:protocollo@pec.agid.gov.it). In no case may
-the Agency for Digital Italy be held liable for damages of any nature caused
-directly or indirectly by access to the site, by the inability or impossibility
-of accessing it. The links to external sites, indicated on this site, are
-provided as a mere service to users, with the exclusion of any responsibility
-for the correctness and completeness of the set of links. The links do not
-imply on the part of the Agency for Digital Italy any kind of approval or
-sharing of responsibility in relation to the legitimacy, completeness and
-correctness of the information contained on the linked sites.
+## Collegamenti a siti esterni e contenuti incorporati
+
+I collegamenti a siti esterni di terzi, indicati nel presente sito, nonché i
+contenuti incorporati di terzi sono forniti come semplice servizio agli utenti.
+L’indicazione dei collegamenti a siti esterni di terzi o l’inserimento di
+contenuti incorporati di terzi non implica da parte della Presidenza del
+Consiglio dei Ministri alcun tipo di approvazione o condivisione di
+responsabilità in relazione alla legittimità, alla completezza e alla
+correttezza delle informazioni contenute nei siti indicati.
+
+## Social media policy
+
+La Presidenza del Consiglio dei Ministri - Dipartimento per la trasformazione
+digitale utilizza i social media per finalità istituzionali, per accrescere la
+trasparenza e la conoscenza delle proprie attività: informa, comunica, ascolta e
+pubblica contenuti di carattere istituzionale.
+
+I contenuti pubblicati comprendono immagini, video, comunicati stampa,
+informazioni di servizio, notizie relative all’attività del Dipartimento nonché
+opportunità di coinvolgimento e partecipazione dei cittadini.
+
+Attraverso i propri canali social, il Dipartimento può condividere e rilanciare
+contenuti e messaggi di pubblico interesse e utilità pubblicate da altri utenti.
+Laddove pubblicati direttamente dal Dipartimento, tutti i contenuti sono
+rilasciati secondo il principio di open by default con licenza
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode.it).
+
+Trattiamo i tuoi dati personali come previsto nella privacy policy di questo
+sito.
+
+Il Dipartimento si impegna a gestire spazi di comunicazione e dialogo
+all’interno dei propri profili, costantemente monitorati, nei diversi social
+media, chiedendo ai propri utenti il rispetto di alcune semplici regole:
+
+* A tutti si chiede di esporre la propria opinione con correttezza, misura e rispetto.
+* Nei social media ognuno è responsabile dei contenuti che pubblica e delle
+  opinioni che esprime. Non saranno comunque tollerati insulti, volgarità, offese,
+  minacce e, in generale, atteggiamenti discriminatori, violenti o diffamatori.
+* I contenuti pubblicati devono rispettare sempre la privacy delle persone.
+  Vanno evitati riferimenti a fatti o a dettagli privi di rilevanza pubblica e
+  che ledano la sfera personale di terzi.
+* L’interesse degli argomenti rispetto alle attività della Presidenza del
+  Consiglio dei Ministri è un requisito essenziale: non è possibile in alcun
+  modo utilizzare questi spazi per scopi diversi da quelli istituzionali.
+* Ogni discussione è legata a un tema specifico: a tutti i partecipanti è
+  richiesto di rispettarlo.
+* Non sarà tollerata alcuna forma di pubblicità, spam o promozione di interessi
+  privati o di attività illegali.
+* Non sono ammessi contenuti che violino il diritto d’autore né l’utilizzo non
+  autorizzato di marchi registrati.
+
+In ogni caso, ove il social media lo permetta, saranno rimossi dallo staff
+tutti i post, i commenti o i materiali audio/video che:
+
+* presentano un linguaggio inappropriato e/o un tono minaccioso, violento,
+  volgare o irrispettoso;
+* presentano contenuti illeciti o di incitamento a compiere attività illecite;
+* hanno contenuti offensivi, ingannevoli, allarmistici, o in violazione di
+  diritti di terzi;
+* divulgano dati e informazioni personali o che possono cagionare danni o ledere
+  la reputazione di terzi;
+* presentano contenuti a contenuto osceno, pornografico o pedopornografico, o
+  tale da offendere la sensibilità degli utenti;
+* hanno un contenuto discriminatorio per genere, razza, etnia, lingua, credo
+  religioso, opinioni politiche, orientamento sessuale, età, condizioni
+  personali e sociali;
+* promuovono o sostengono attività illegali, che violano il copyright o diritti
+  di terzi.
+
+Per chi dovesse violare ripetutamente queste condizioni, quelle contenute nelle
+policy degli strumenti adottati o comunque mette a rischio la sicurezza dei
+sistemi, il Dipartimento si riserva il diritto di usare il ban o il blocco
+(quando possibile dopo un primo avvertimento) per impedire ulteriori interventi,
+e di segnalare l’utente ai responsabili della piattaforma ed eventualmente alle
+forze dell’ordine.

--- a/it/note-legali.md
+++ b/it/note-legali.md
@@ -6,26 +6,99 @@ ref:
 layout: internal-long
 ---
 
-[https://developers.italia.it](https://developers.italia.it) è un sito che ha l’obiettivo di contribuire alla crescita e al coordinamento di una community di sviluppatori interessati allo sviluppo di codice strumentale al funzionamento dei servizi online della pubblica amministrazione.
-Il sito è gestito dall'Agenzia per l'Italia Digitale.
+La Presidenza del Consiglio dei Ministri - Dipartimento per la trasformazione
+digitale, con sede in Largo Pietro di Brazzà 86, 00186 Roma, ha realizzato
+questo sito con lo scopo di contribuire alla crescita e al coordinamento di
+una community interessata allo sviluppo di codice strumentale al funzionamento
+dei servizi online della pubblica amministrazione.
 
-In taluni casi (forum di discussione) per accedere ai contenuti e/o fruire dei Servizi potrebbe essere necessario utilizzare delle credenziali rilasciate dai gestori di altri servizi (es: github o google) o registrarsi, richiedendo l’attribuzione di nuove credenziali.
-L'utente prende atto che l’Agenzia, nel corso dell'intero rapporto, lo identificherà quale titolare dei suoi diritti e doveri esclusivamente sulla base dell'identità digitale attribuitagli e rappresentata dalle credenziali (user ID/email e password) che avrà indicato e/o scelto di utilizzare. L'utente si impegna pertanto a custodire tali credenziali e a segnalare immediatamente all’Agenzia – qualora avesse scelto di registrarsi direttamente al Sito – all'indirizzo [protocollo@pec.agid.gov.it](mailto:protocollo@pec.agid.gov.it) l’eventuale perdita del controllo esclusivo sulle stesse, prendendo atto della circostanza che, in difetto di tale segnalazione e sino al momento del suo ricevimento, sarà responsabile di ogni azione e condotta posta in essere utilizzando tali credenziali (es: pubblicazione di un contenuto online, richiesta di un Servizio ecc.) e non potrà in alcun modo contestare la fruizione dei servizi o l'accesso ai contenuti connessi all'utilizzo delle citate credenziali.
+## Licenza dei contenuti
 
-Qualora l'utente, attraverso taluni Servizi disponibili sul Sito (es. forum di discussione), possa procedere alla pubblicazione, diffusione o comunicazione di contenuti, si impegna a pubblicare, diffondere o comunicare esclusivamente contenuti inidonei a violare la legge e/o qualsivoglia diritto di terzi. 
-In tal caso, inoltre, l'utente dichiara e garantisce di disporre di tutti i diritti necessari alla pubblicazione dei contenuti (testi, immagini, fotografie e/o ritratti, filmati, materiale audiovisivo), avendo, eventualmente, preventivamente ottenuto, ove necessario, tutti i consensi e le liberatorie previsti dalla disciplina vigente, con particolare – ma non esclusivo – riferimento alla legge sul diritto d'autore e alla disciplina sulla privacy.
-L'Utente si impegna sin d'ora a manlevare e mantenere garantite ed indenni l’Agenzia per l’Italia digitale da ogni richiesta, anche risarcitoria, proposta e/o derivante, direttamente ovvero indirettamente, dall'utilizzo da parte dell'utente medesimo dei Servizi e/o dalla pubblicazione di qualsivoglia contenuto. Ai fini di tale manleva, si considererà imputabile all'utente qualsivoglia condotta posta in essere utilizzando le credenziali a quest'ultimo attribuite, salvo non ne venga comunicata la perdita alla Società in epoca anteriore alla citata condotta. 
-Resta inteso che l’Agenzia per l’Italia digitale si riserva il diritto di rimuovere in qualsiasi momento qualsiasi contenuto pubblicato dall'utente attraverso i servizi a fronte della segnalazione di una pretesa violazione di diritti di terzi o comunque a proprio insindacabile giudizio. 
-L'Utente concede all’Agenzia per l’Italia digitale il diritto e la licenza, non soggetti ad alcun compenso – e come tali completamente gratuiti – e non esclusivi, di utilizzare, adattare, pubblicare, distribuire, riprodurre ed eseguire senza limitazioni territoriali e/o temporali quanto trasmesso, inviato e pubblicato dall'Utente attraverso i servizi. 
-Le previsioni che precedono relative alla pubblicazione di contenuti attraverso il sito non si applicano alla pubblicazione di codice sorgente attraverso il servizio Github richiamato dal sito. Tale pubblicazione rimane assoggettata alle condizioni di utilizzo accettate dagli utenti all’atto dell’accesso alla relativa piattaforma di discussione.
+In applicazione del principio open by default ai sensi dell’articolo 52 del
+decreto legislativo 7 marzo 2005, n. 82 (CAD) e salvo dove diversamente
+specificato (compresi i contenuti incorporati di terzi), i dati, i documenti e
+le informazioni pubblicati sul sito sono rilasciati con licenza
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode.it).
 
-La titolarità di tutti i documenti e contenuti (testi, presentazioni, immagini, foto, video, ecc.) è dell'Agenzia per l'Italia Digitale.
-La visualizzazione, il download e qualunque utilizzo dei dati pubblicati sul Sito comporta accettazione delle presenti note legali e delle condizioni della licenza con cui sono pubblicati.
-Salvo ove diversamente indicato, i contenuti pubblicati sul presente sito sono messi a disposizione con licenza CC–BY 3.0, il cui testo integrale è disponibile al seguente indirizzo: [https://creativecommons.org/licenses/by/3.0/it/legalcode](https://creativecommons.org/licenses/by/3.0/it/legalcode).
-Questo significa che, ove non diversamente specificato, i contenuti di questo sito sono liberamente distribuibili e riutilizzabili, a patto che sia sempre citata la fonte e – ove possibile – riportato l'indirizzo web della pagina originale.
-Il codice sorgente del Sito è invece disponibile qui sulla piattaforma Github e, pertanto, riutilizzabile nei limiti di cui alla relativa licenza.
-L'Agenzia per l'Italia Digitale si impegna costantemente per assicurare la qualità delle informazioni pubblicate sul sito, nonché la loro integrità, aggiornamento , completezza, tempestività , semplicità di consultazione e accessibilità.
-Per qualunque segnalazione o suggerimento è possibile scrivere all’indirizzo [protocollo@pec.agid.gov.it](mailto:protocollo@pec.agid.gov.it).
-In nessun caso l'Agenzia per l'Italia Digitale può essere ritenuta responsabile dei danni di qualsiasi natura causati direttamente o indirettamente dall'accesso al sito, dall'incapacità o impossibilità di accedervi.
-I collegamenti a siti esterni, indicati nel presente sito, sono forniti come semplice servizio agli utenti, con esclusione di ogni responsabilità sulla correttezza e sulla completezza dell’insieme dei collegamenti indicati.
-L’indicazione dei collegamenti non implica da parte dell'Agenzia per l'Italia Digitale alcun tipo di approvazione o condivisione di responsabilità in relazione alla legittimità, alla completezza e alla correttezza delle informazioni contenute nei siti indicati.
+Gli utenti sono quindi liberi di condividere (riprodurre, distribuire,
+comunicare al pubblico, esporre in pubblico, rappresentare, eseguire e recitare
+questo materiale con qualsiasi mezzo e formato) e modificare (trasformare il
+materiale e utilizzarlo per opere derivate) per qualsiasi fine, anche
+commerciale con il solo onere di attribuzione, senza apporre restrizioni
+aggiuntive.
+
+## Collegamenti a siti esterni e contenuti incorporati
+
+I collegamenti a siti esterni di terzi, indicati nel presente sito, nonché i
+contenuti incorporati di terzi sono forniti come semplice servizio agli utenti.
+L’indicazione dei collegamenti a siti esterni di terzi o l’inserimento di
+contenuti incorporati di terzi non implica da parte della Presidenza del
+Consiglio dei Ministri alcun tipo di approvazione o condivisione di
+responsabilità in relazione alla legittimità, alla completezza e alla
+correttezza delle informazioni contenute nei siti indicati.
+
+## Social media policy
+
+La Presidenza del Consiglio dei Ministri - Dipartimento per la trasformazione
+digitale utilizza i social media per finalità istituzionali, per accrescere la
+trasparenza e la conoscenza delle proprie attività: informa, comunica, ascolta e
+pubblica contenuti di carattere istituzionale.
+
+I contenuti pubblicati comprendono immagini, video, comunicati stampa,
+informazioni di servizio, notizie relative all’attività del Dipartimento nonché
+opportunità di coinvolgimento e partecipazione dei cittadini.
+
+Attraverso i propri canali social, il Dipartimento può condividere e rilanciare
+contenuti e messaggi di pubblico interesse e utilità pubblicate da altri utenti.
+Laddove pubblicati direttamente dal Dipartimento, tutti i contenuti sono
+rilasciati secondo il principio di open by default con licenza
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode.it).
+
+Trattiamo i tuoi dati personali come previsto nella privacy policy di questo
+sito.
+
+Il Dipartimento si impegna a gestire spazi di comunicazione e dialogo
+all’interno dei propri profili, costantemente monitorati, nei diversi social
+media, chiedendo ai propri utenti il rispetto di alcune semplici regole:
+
+* A tutti si chiede di esporre la propria opinione con correttezza, misura e rispetto.
+* Nei social media ognuno è responsabile dei contenuti che pubblica e delle
+  opinioni che esprime. Non saranno comunque tollerati insulti, volgarità, offese,
+  minacce e, in generale, atteggiamenti discriminatori, violenti o diffamatori.
+* I contenuti pubblicati devono rispettare sempre la privacy delle persone.
+  Vanno evitati riferimenti a fatti o a dettagli privi di rilevanza pubblica e
+  che ledano la sfera personale di terzi.
+* L’interesse degli argomenti rispetto alle attività della Presidenza del
+  Consiglio dei Ministri è un requisito essenziale: non è possibile in alcun
+  modo utilizzare questi spazi per scopi diversi da quelli istituzionali.
+* Ogni discussione è legata a un tema specifico: a tutti i partecipanti è
+  richiesto di rispettarlo.
+* Non sarà tollerata alcuna forma di pubblicità, spam o promozione di interessi
+  privati o di attività illegali.
+* Non sono ammessi contenuti che violino il diritto d’autore né l’utilizzo non
+  autorizzato di marchi registrati.
+
+In ogni caso, ove il social media lo permetta, saranno rimossi dallo staff
+tutti i post, i commenti o i materiali audio/video che:
+
+* presentano un linguaggio inappropriato e/o un tono minaccioso, violento,
+  volgare o irrispettoso;
+* presentano contenuti illeciti o di incitamento a compiere attività illecite;
+* hanno contenuti offensivi, ingannevoli, allarmistici, o in violazione di
+  diritti di terzi;
+* divulgano dati e informazioni personali o che possono cagionare danni o ledere
+  la reputazione di terzi;
+* presentano contenuti a contenuto osceno, pornografico o pedopornografico, o
+  tale da offendere la sensibilità degli utenti;
+* hanno un contenuto discriminatorio per genere, razza, etnia, lingua, credo
+  religioso, opinioni politiche, orientamento sessuale, età, condizioni
+  personali e sociali;
+* promuovono o sostengono attività illegali, che violano il copyright o diritti
+  di terzi.
+
+Per chi dovesse violare ripetutamente queste condizioni, quelle contenute nelle
+policy degli strumenti adottati o comunque mette a rischio la sicurezza dei
+sistemi, il Dipartimento si riserva il diritto di usare il ban o il blocco
+(quando possibile dopo un primo avvertimento) per impedire ulteriori interventi,
+e di segnalare l’utente ai responsabili della piattaforma ed eventualmente alle
+forze dell’ordine.


### PR DESCRIPTION
Update Italian and English legal notices citing the DTD as owner.

Use the Italian text for English as well until there's a translation.