### PR TITLE
chore: make html-proofer ignore software's description

### DIFF
--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -694,7 +694,14 @@ layout: default
             </div>
             <div class="col-md-8 col-offset-md-1 page-detail">
               <p class="title">{{ t.software.extende_description }}</p>
-              <div class="font-serif page-detail__text">
+              <!--
+                Use data-proofer-ignore to make html-proofer ignore this section for now:
+                it comes from external publiccode.yml files so there might be broken links
+                out of our control making our CI pipeline fail.
+
+                TODO: find a better solution
+              -->
+              <div class="font-serif page-detail__text" data-proofer-ignore>
                 {{ description.longDescription | markdownify }}
               </div>
             </div>


### PR DESCRIPTION
Software's description comes from external publiccode.yml files
so there might be broken links out of our control making our CI pipeline fail.

In case that happens, it's still a broken link published on
developers.italia.it, so we'll have to find a better solution in the
future.