### PR TITLE
feat: add PNRR search to the search engine

### DIFF
--- a/assets/js/api/elasticSearchUtils.js
+++ b/assets/js/api/elasticSearchUtils.js
@@ -3,10 +3,12 @@ import { lang } from '../utils/l10n.js';
 
 export const buildFilter = (filters) => {
   let { intendedAudiences, categories, developmentStatuses } = filters;
+  const { pnrr, pnrrTarget, pnrrMeasure } = filters;
+
   intendedAudiences = Array.isArray(intendedAudiences) ? intendedAudiences : [];
   categories = Array.isArray(categories) ? categories : [];
   developmentStatuses = Array.isArray(developmentStatuses) ? developmentStatuses : [];
-  return [
+  const ret = [
     ...intendedAudiences.map((filterValue) => ({
       term: { 'publiccode.intendedAudience.scope': filterValue },
     })),
@@ -15,6 +17,25 @@ export const buildFilter = (filters) => {
       term: { 'publiccode.developmentStatus': filterValue },
     })),
   ];
+
+  if (pnrr) {
+    // Not a keyword because we want match "PNRR/Beneficiari" or "PNRR/Misure" even if
+    // the feature "PNRR" is not in the publiccode.yml file.
+    ret.push({ term: { [`publiccode.description.${lang}.features`]: 'pnrr' } });
+  }
+
+  if (pnrrTarget !== null) {
+    // We want exact match here and case sensitivity because PNRR features are basically
+    // tags we came up with to mark certain type of software (the ones that help Public administrations
+    // with the PNRR - https://www.governo.it/sites/governo.it/files/PNRR.pdf) - hence the
+    // keyword search.
+    ret.push({ term: { [`publiccode.description.${lang}.features.keyword`]: `PNRR/Beneficiari/${pnrrTarget}` } });
+  }
+  if (pnrrMeasure !== null) {
+    ret.push({ term: { [`publiccode.description.${lang}.features.keyword`]: `PNRR/Misura/${pnrrMeasure}` } });
+  }
+
+  return ret;
 };
 
 export const buildSort = (sortBy) => {

--- a/assets/js/components/Catalogue/CatalogueContainer.js
+++ b/assets/js/components/Catalogue/CatalogueContainer.js
@@ -5,6 +5,9 @@ import {
   initialCategories,
   initialDevelopmentStatuses,
   initialIntendedAudiences,
+  initialPnrr,
+  initialPnrrTarget,
+  initialPnrrMeasure,
   initialPage,
   initialSearchValue,
   initialSortBy,
@@ -33,6 +36,9 @@ export const CatalogueContainer = () => {
       initialDevelopmentStatuses={initialDevelopmentStatuses}
       initialPage={Number(initialPage)}
       initialIntendedAudiences={initialIntendedAudiences}
+      initialPnrr={initialPnrr}
+      initialPnrrTarget={initialPnrrTarget}
+      initialPnrrMeasure={initialPnrrMeasure}
       initialSearchValue={initialSearchValue}
       initialSortBy={initialSortBy ?? defaultSortBy}
       initialType={initialType ?? ALL_CATALOGUE}

--- a/assets/js/contexts/searchContext.js
+++ b/assets/js/contexts/searchContext.js
@@ -147,10 +147,6 @@ export const setFilterIntendedAudience = (intendedAudience) => ({
   value: intendedAudience,
 });
 
-// export const setFilterPnrr = (pnrr) => ({ type: SET_FILTERS_PNRR, value: pnrr });
-// export const setFilterPnrrTarget = (target) => ({ type: SET_FILTERS_PNRR_TARGET, value: target });
-// export const setFilterPnrrMeasure = (measure) => ({ type: SET_FILTERS_PNRR_MEASURE, value: measure });
-
 export const setType = (type) => ({
   type: SET_TYPE,
   value: type,

--- a/assets/js/contexts/searchContext.js
+++ b/assets/js/contexts/searchContext.js
@@ -8,6 +8,9 @@ const SET_SEARCH_VALUE = 'SET_SEARCH_VALUE';
 const SET_FILTERS_CATEGORIES = 'SET_FILTERS_CATEGORIES';
 const SET_FILTERS_INTENDED_AUDIENCES = 'SET_FILTERS_INTENDED_AUDIENCES';
 const SET_FILTERS_DEVELOPMENT_STATUSES = 'SET_FILTERS_DEVELOPMENT_STATUSES';
+const SET_FILTERS_PNRR = 'SET_FILTERS_DEVELOPMENT_STATUSES';
+const SET_FILTERS_PNRR_TARGET = 'SET_FILTERS_DEVELOPMENT_TARGET';
+const SET_FILTERS_PNRR_MEASURE = 'SET_FILTERS_DEVELOPMENT_MEASURE';
 const SET_SORT_BY = 'SET_SORT_BY';
 const SET_TYPE = 'SET_TYPE';
 
@@ -39,6 +42,24 @@ export const searchReducer = (state, action) => {
         filterIntendedAudiences: action.value,
         page: 0,
       };
+    case SET_FILTERS_PNRR:
+      return {
+        ...state,
+        filterPnrr: action.value,
+        page: 0,
+      };
+    case SET_FILTERS_PNRR_TARGET:
+      return {
+        ...state,
+        filterPnrrTarget: action.value,
+        page: 0,
+      };
+    case SET_FILTERS_PNRR_MEASURE:
+      return {
+        ...state,
+        filterPnrrMeasure: action.value,
+        page: 0,
+      };
     case SET_TYPE:
       return {
         ...state,
@@ -67,6 +88,9 @@ export const SearchProvider = ({
   initialDevelopmentStatuses = [],
   initialPage = 0,
   initialIntendedAudiences = [],
+  initialPnrr = false,
+  initialPnrrTarget = null,
+  initialPnrrMeasure = null,
   initialSearchValue = '',
   initialSortBy = RELEVANCE,
   initialType = ALL_SITE,
@@ -77,6 +101,9 @@ export const SearchProvider = ({
     filterCategories: initialCategories,
     filterDevelopmentStatuses: initialDevelopmentStatuses,
     filterIntendedAudiences: initialIntendedAudiences,
+    filterPnrr: initialPnrr,
+    filterPnrrTarget: initialPnrrTarget,
+    filterPnrrMeasure: initialPnrrMeasure,
     page: initialPage,
     searchValue: initialSearchValue,
     sortBy: initialSortBy,
@@ -97,6 +124,11 @@ SearchProvider.propTypes = {
   initialDevelopmentStatuses: PropTypes.arrayOf(PropTypes.string),
   initialPage: PropTypes.number,
   initialIntendedAudiences: PropTypes.arrayOf(PropTypes.string),
+
+  initialPnrr: PropTypes.bool,
+  initialPnrrTarget: PropTypes.string,
+  initialPnrrMeasure: PropTypes.string,
+
   initialSearchValue: PropTypes.string,
   initialSortBy: PropTypes.string,
   initialType: PropTypes.string,
@@ -114,6 +146,10 @@ export const setFilterIntendedAudience = (intendedAudience) => ({
   type: SET_FILTERS_INTENDED_AUDIENCES,
   value: intendedAudience,
 });
+
+// export const setFilterPnrr = (pnrr) => ({ type: SET_FILTERS_PNRR, value: pnrr });
+// export const setFilterPnrrTarget = (target) => ({ type: SET_FILTERS_PNRR_TARGET, value: target });
+// export const setFilterPnrrMeasure = (measure) => ({ type: SET_FILTERS_PNRR_MEASURE, value: measure });
 
 export const setType = (type) => ({
   type: SET_TYPE,

--- a/assets/js/hooks/useSearchEngine.js
+++ b/assets/js/hooks/useSearchEngine.js
@@ -52,8 +52,18 @@ const areMoreItemsAvailable = (from, size, total) => from + size < total;
 export const useSearchEngine = ({ pageSize } = { pageSize: 12 }) => {
   const [{ items, total, isLoading, errorMessage }, dispatch] = useReducer(reducer, initial);
   const dispatchGlobal = useContext(searchContextDispatch);
-  const { filterCategories, filterDevelopmentStatuses, filterIntendedAudiences, page, type, searchValue, sortBy } =
-    useContext(searchContextState);
+  const {
+    filterCategories,
+    filterDevelopmentStatuses,
+    filterIntendedAudiences,
+    filterPnrr,
+    filterPnrrTarget,
+    filterPnrrMeasure,
+    page,
+    type,
+    searchValue,
+    sortBy,
+  } = useContext(searchContextState);
   // This feature is mainly used by the infiniteScroll to reload the previous items just after an user click on the browser back button
   const reloadItemsUntilPage = useRef(page > 0 ? page : false);
   // If we aren't in the "resume mode" the from is incremental
@@ -78,6 +88,9 @@ export const useSearchEngine = ({ pageSize } = { pageSize: 12 }) => {
             categories: filterCategories,
             developmentStatuses: filterDevelopmentStatuses,
             intendedAudiences: filterIntendedAudiences,
+            pnrr: filterPnrr,
+            pnrrTarget: filterPnrrTarget,
+            pnrrMeasure: filterPnrrMeasure,
           },
           searchValue,
           sortBy,
@@ -109,6 +122,9 @@ export const useSearchEngine = ({ pageSize } = { pageSize: 12 }) => {
     filterCategories,
     filterDevelopmentStatuses,
     filterIntendedAudiences,
+    filterPnrr,
+    filterPnrrTarget,
+    filterPnrrMeasure,
     sortBy,
     page,
     from,

--- a/assets/js/utils/urlSearchParams.js
+++ b/assets/js/utils/urlSearchParams.js
@@ -3,6 +3,9 @@ export const initialCategories = urlSearchParams.getAll('categories');
 export const initialDevelopmentStatuses = urlSearchParams.getAll('development_statuses');
 export const initialPage = urlSearchParams.get('page');
 export const initialIntendedAudiences = urlSearchParams.getAll('intended_audiences');
+export const initialPnrr = urlSearchParams.has('pnrr');
+export const initialPnrrTarget = urlSearchParams.get('pnrr_target');
+export const initialPnrrMeasure = urlSearchParams.get('pnrr_measure');
 export const initialSearchValue = urlSearchParams.get('search_value');
 export const initialSortBy = urlSearchParams.get('sort_by');
 export const initialType = urlSearchParams.get('type');
@@ -11,6 +14,9 @@ export const serializeStateToQueryString = ({
   filterCategories,
   filterDevelopmentStatuses,
   filterIntendedAudiences,
+  filterPnrr,
+  filterPnrrTarget,
+  filterPnrrMeasure,
   page,
   type,
   searchValue,
@@ -21,6 +27,17 @@ export const serializeStateToQueryString = ({
   filterCategories.forEach((f) => urlSearchParams.append('categories', f));
   filterDevelopmentStatuses.forEach((f) => urlSearchParams.append('development_statuses', f));
   filterIntendedAudiences.forEach((f) => urlSearchParams.append('intended_audiences', f));
+
+  if (filterPnrr) {
+    urlSearchParams.append('pnrr', '1');
+  }
+  if (filterPnrrTarget !== null) {
+    urlSearchParams.append('pnrr_target', filterPnrrTarget);
+  }
+  if (filterPnrrMeasure !== null) {
+    urlSearchParams.append('pnrr_measure', filterPnrrMeasure);
+  }
+
   urlSearchParams.set('type', type);
   urlSearchParams.set('sort_by', sortBy);
   searchValue && urlSearchParams.set('search_value', searchValue);


### PR DESCRIPTION
Add the capability of searching for PNNR related software.

We came up with the convention that Italian publiccode.yml files can put
"tags" in "description.it.features" to mark software that help Public administrations
with the PNRR (https://www.governo.it/sites/governo.it/files/PNRR.pdf).

We have three kinds of tags:

1. "PNRR" as the general tag
   It can be searched by adding "pnrr=1" to the query string
2. "PNRR/Beneficiari/$TARGET_NAME" the target the software is made for,
   fe. "Scuole" (Schools), "Comuni".
   It can be searched by adding "pnrr_target=$TARGET_NAME" to the query
   string (case sensitive)
3. "PNRR/Misura/$NUMBER" the PNRR measure, fe "1.4.1"
   It can be searched by adding "pnrr_measure=$NUMBER" to the query
   string

Fix #1207

cc @mfortini 