### PR TITLE
feat(mailing list): assign the "Des+Dev" tag when registering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,6 +109,8 @@ newsletterdata:
    args:
      # Sendportal workspace id
      workspace_id: 1
+     # Des+Dev tag in Sendportal
+     tag_id: 7
 
 collections:
    platforms:


### PR DESCRIPTION
Automatically assign the Sendportal "Des+Dev" tag when the user
confirms the registration.

Fix #1213.