### PR TITLE
chore: better text on mailing list confirmation

### DIFF
--- a/assets/js/components/MailingList/MailingListConfirmation.js
+++ b/assets/js/components/MailingList/MailingListConfirmation.js
@@ -6,7 +6,8 @@ const messages = {
     loading: 'Iscrizione in corso...',
     placeholder: 'indirizzo email',
     errorText: 'Qualcosa è andato storto 😔 Riprova più tardi',
-    successText: "L'iscrizione è andata a buon fine, riceverai aggiornamenti sulle nostre iniziative!",
+    successText:
+      "L'iscrizione è andata a buon fine, riceverai aggiornamenti sulle iniziative di Developers e Designers Italia!",
   },
   en: {
     loading: 'Subscribing...',


### PR DESCRIPTION
Make it clear in the mailing list confirmation page that the user
will receive both Developers and Designers Italia emails.