### PR TITLE
feat: add a way to show all the categories in software page

### DIFF
--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -61,7 +61,7 @@ layout: default
               {% endfor %}
             </ul>
             {% if page.publiccode.categories.size > 5 %}
-            <a href="#" id="moreTags">{{ t.software.show_all }}</a>
+            <a href="#" id="moreTags">{{ t.software.show_all }}...</a>
             {% endif %}
           </div>
           <div class="row legal-main-info">

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -51,10 +51,20 @@ layout: default
           </h3>
           <div class="my-3">
             <ul class="home-software-tags__list list-inline">
-              {% for tag in page.popularCategories limit: 3 %}
-              {% include set-tag.html tag=tag %}
+              {% assign deactive = false %}
+              {% for tag in page.publiccode.categories %}
+                {% if forloop.index > 5 %}
+                  {% assign deactive = true %}
+                {% endif %}
+
+                {% include set-tag.html tag=tag deactive=deactive %}
               {% endfor %}
             </ul>
+            {% if page.publiccode.categories.size > 5 %}
+            <div class="text-center mb-2 mb-md-4">
+              <a href="#" id="moreTags" class="btn btn-primary mx-auto">{{ t.home_tags_more }}</a>
+            </div>
+            {% endif %}
           </div>
           <div class="row legal-main-info">
             <div class="col-sm">

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -61,9 +61,7 @@ layout: default
               {% endfor %}
             </ul>
             {% if page.publiccode.categories.size > 5 %}
-            <div class="text-center mb-2 mb-md-4">
-              <a href="#" id="moreTags" class="btn btn-primary mx-auto">{{ t.home_tags_more }}</a>
-            </div>
+            <a href="#" id="moreTags">{{ t.software.show_all }}</a>
             {% endif %}
           </div>
           <div class="row legal-main-info">


### PR DESCRIPTION
Add a link to show all the categories in the software page and display
at least five categories by default.

Fix #1230.