### PR TITLE
chore(ci): relax commitlint severity to warning

### DIFF
--- a/Dangerfile.js
+++ b/Dangerfile.js
@@ -3,7 +3,7 @@ const configConventional = require('@commitlint/config-conventional');
 
 (async () => {
   const commitlintConfig = {
-    severity: 'fail'
+    severity: 'warn',
   };
   await commitlint(configConventional.rules, commitlintConfig);
 })();


### PR DESCRIPTION
Commitlint was kind of a failure and it ends up just being an annoyance, sadly.