### PR TITLE
feat(container): container podman friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.6-browsers
+FROM docker.io/cimg/ruby:2.6-browsers
 
 ENV PORT 4000
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ bundle-setup:
 	gem install bundler:2.1.4
 
 bundle-install: bundle-setup
+	bundle config set path vendor/
 	bundle install
 
 bundle-install-deployment: bundle-setup
+	bundle config set path vendor/
 	bundle install --deployment
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   elasticsearch:
-    image: italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
+    image: docker.io/italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
     ports:
       - 9200:9200
     networks:
@@ -30,10 +30,10 @@ services:
     # folders which content changes through a build:
     # assets, _data, node_modules, vendor
     volumes:
-      - .:/usr/src/developers.italia.it
-      - /usr/src/developers.italia.it/_data/crawler
-      - /usr/src/developers.italia.it/node_modules
-      - /usr/src/developers.italia.it/vendor
+      - .:/usr/src/developers.italia.it:Z
+      - /usr/src/developers.italia.it/_data/crawler:Z
+      - /usr/src/developers.italia.it/node_modules:Z
+      - /usr/src/developers.italia.it/vendor:Z
     depends_on:
       - elasticsearch
     command: ["wait-for-it", "elasticsearch:9200", "--timeout=60", "--", "make", "local"]


### PR DESCRIPTION
container podman friendly selinux too

## Description

<!--- Describe in details the proposed changes -->
With these changes you can use `podman-compose up --build` without any manual intervention, also works with selinux enabled
**WARNING**
I don't have a docker machine at hand to test with docker.
