### PR TITLE
fix: "More tags" button scrolls to top

### DIFF
--- a/_includes/home-software-categories.html
+++ b/_includes/home-software-categories.html
@@ -14,7 +14,7 @@
 
         {% if site.data.publiccode_categories.size > 15 %}
         <div class="text-center mb-2 mb-md-4">
-            <a href="#" id="moreTags" class="btn btn-primary mx-auto">{{ t.home_tags_more }}</a>
+            <a id="moreTags" class="btn btn-primary mx-auto">{{ t.home_tags_more }}</a>
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
The "More tags" button on the homepage makes the view scroll to top when clicked.
Removing href="#" prevents this behavior.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [x] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Ready for review! :rocket:

## Fixes
Fixes #1204 
