### PR TITLE
chore(build): fix the build when using bundler > 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,12 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     nokogumbo (2.0.4)
       nokogiri (~> 1.8, >= 1.8.4)
     nuggets (1.6.0)
@@ -114,7 +120,10 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer
@@ -135,4 +144,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.1.4
+   2.3.24

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ download-data:
 	curl -w %{http_code} -s -o /dev/null https://raw.githubusercontent.com/italia/developers.italia.it-data/main/github_issues.json | grep 200
 
 bundle-setup:
-	gem install bundler:2.1.4
+	gem install bundler:2.3.24
 
 bundle-install: bundle-setup
 	bundle install


### PR DESCRIPTION
bundler > 2.1 needs to be instructed on what architectures to use when fetching the binary packages, otherwise it'll always try to compile the gem.

The Vercel preview uses bundler 2.3, so let's bump the version.