### PR TITLE
fix: use the keyword field to filter categories

### DIFF
--- a/assets/js/api/elasticSearchUtils.js
+++ b/assets/js/api/elasticSearchUtils.js
@@ -12,7 +12,7 @@ export const buildFilter = (filters) => {
     ...intendedAudiences.map((filterValue) => ({
       term: { 'publiccode.intendedAudience.scope': filterValue },
     })),
-    ...categories.map((filterValue) => ({ term: { 'publiccode.categories': filterValue } })),
+    ...categories.map((filterValue) => ({ term: { 'publiccode.categories.keyword': filterValue } })),
 
     // We want exact match here and case sensitivity because PNRR features are basically
     // tags we came up with to mark certain type of software (the ones that help Public administrations


### PR DESCRIPTION
`categories` was [already supposed to be a keyword](https://github.com/italia/publiccode-crawler/blob/legacy/elastic/elastic.go#L198-L200), but it isn't in production for some reason.

Elastic's mapping update doesn't work for fields already indexed, so let's add a `keyword` subfield instead of re-indexing everything - which is error prone and can cause downtime.

Fix #1203, Fix #1231

cc @libremente 