### PR TITLE
content: update link to publishers.thirdparty.yml

### DIFF
--- a/en/reuse/publication.md
+++ b/en/reuse/publication.md
@@ -69,4 +69,4 @@ public sector, can be included in the Developers Italia catalogue. As such, it i
 necessary to:
 
 1. fill and include a `publiccode.yml` file in the repository (leaving the `codiceIPA` key empty);
-2. include the repository URL [in the list](https://github.com/italia/publiccode-crawler/blob/main/publishers.thirdparty.yml) by opening a pull request on GitHub.
+2. include the repository URL [in the list](https://github.com/italia/publiccode-crawler/blob/legacy/publishers.thirdparty.yml) by opening a pull request on GitHub.

--- a/it/riuso/pubblicazione.md
+++ b/it/riuso/pubblicazione.md
@@ -50,7 +50,7 @@ La pubblicazione nel catalogo, così come il recepimento degli aggiornamenti, è
 I software open source di terze parti, ovvero non messi a riuso dalla Pubblica Amministrazione ma di potenziale interesse per il settore pubblico, possono essere inclusi nel catalogo di Developers Italia. È necessario a tal fine:
 
 1. compilare ed includere il file `publiccode.yml` nel repositorio (lasciando vuoto il campo `codiceIPA`);
-2. aggiungere l'URL del repositorio [nella lista](https://github.com/italia/publiccode-crawler/blob/main/publishers.thirdparty.yml) aprendo una pull request su GitHub.
+2. aggiungere l'URL del repositorio [nella lista](https://github.com/italia/publiccode-crawler/blob/legacy/publishers.thirdparty.yml) aprendo una pull request su GitHub.
 
 ## PNRR: soluzioni a Catalogo
 


### PR DESCRIPTION
publishers.thirdparty.yml is on the legacy branch, which is from the non-API crawler is build for the time being.