### PR TITLE
chore(container): use explicit repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.6-browsers
+FROM docker.io/cimg/ruby:2.6-browsers
 
 ENV PORT 4000
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   elasticsearch:
-    image: italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
+    image: docker.io/italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
     ports:
       - 9200:9200
     networks:


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
This PR tackles:

* use explicit repo (docker.io) for containers in docker-compose and Dockerfile

this enables podman compatibility in image pulling


* [x ] Have you successfully ran tests with your changes locally?
* [ x] Ready for review! :rocket:
