### PR TITLE
fix(container): missing es in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.3'
 
 services:
+  elasticsearch:
     image: docker.io/italia/publiccode-tools-elasticsearch:ceb40894eaa142c8aec55c8dbcc9df038ec491e1
     environment:
       - cluster.routing.allocation.disk.threshold_enabled=false


### PR DESCRIPTION
## Description

`elasticsearch`  service was missing in docker-compose

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->
* [ *] Ready for review! :rocket:

## Fixes
`elasticsearch`  service was missing in docker-compose

