### PR TITLE
content: remove report API section and update content

### DIFF
--- a/en/how-to-participate.md
+++ b/en/how-to-participate.md
@@ -36,7 +36,6 @@ alternate-blocks:
         - label: Explore the catalogue
           class: btn btn-primary
           url: '/en/software'
-pair-blocks:
     - title: "Add public code to the catalogue"
       text: "Help populate the [catalogue](/en/software) finding software
       released as open source by Public Administrations, or third party open

--- a/en/how-to-participate.md
+++ b/en/how-to-participate.md
@@ -1,6 +1,6 @@
 ---
-title: How to participate 
-lang: en 
+title: How to participate
+lang: en
 ref:
   it: /it/come-partecipo
 layout: internal-simple
@@ -16,13 +16,13 @@ alternate-blocks:
       resources? Contact them over GitHub or Slack."
       image: /assets/images/come-partecipo-3.svg
       buttons:
-        - label: Discover the platforms 
+        - label: Discover the platforms
           class: btn btn-primary
           url: '/en/platforms'
         - label: Explore GitHub Italia
           class: btn btn-outline-primary
           url: 'https://github.com/italia'
-        - label: Chat on Slack 
+        - label: Chat on Slack
           class: btn btn-outline-primary
           url: 'https://slack.developers.italia.it/'
     - title: "Participate to the public software development"
@@ -33,7 +33,7 @@ alternate-blocks:
       help"
       image: /assets/images/come-partecipo-4.svg
       buttons:
-        - label: Explore the catalogue 
+        - label: Explore the catalogue
           class: btn btn-primary
           url: '/en/software'
 pair-blocks:
@@ -42,23 +42,12 @@ pair-blocks:
       released as open source by Public Administrations, or third party open
       source software designed for the public sector: helping the maintainers
       to insert a `publiccode.yml` file in their repository you will allow the
-      Developers Italia crawler to discover them." 
+      Developers Italia crawler to discover them."
       image: /assets/images/come-partecipo-1.svg
       buttons:
         - label: Find more
           class: btn btn-primary
           url: '/en/reuse/publication'
-    - title: "Report new available APIs"
-      text: "Many public services expose interoperability interfaces. The
-      Developers Italia [catalogue](/en/api) has the objective to show all of
-      them to the developers who would like to imagine new integrated
-      services. If you know some APIs which are not present, or you are
-      creating them, send us a report!"
-      image: /assets/images/come-partecipo-2.svg
-      buttons:
-        - label: Report an API
-          class: btn btn-primary
-          url: '/en/contacts'
 ---
 
 Developers Italia is a collaborative community opened to everyone's contribute:

--- a/en/how.md
+++ b/en/how.md
@@ -32,15 +32,15 @@ alternate-blocks:
           class: btn btn-white btn-outline-primary
           url: '/en/reuse'
     - title: "I want to integrate with a public service through APIs"
-      text: "The API catalogue contains a collection of public services
-      accessible throughout interoperability, together with the relative documentation
-      and the OpenAPI descriptions, in order to allow building modern digital
-      public services."
+      text: |
+        You will find all the information, resources, and available channels on how to integrate the
+        services of public administrations through APIs in the pages dedicated to Interoperability
+        and the National Digital Data Platform (PDND),
       image: /assets/images/come-lo-uso-3.svg
       buttons:
-        - label: "Discover public APIs"
+        - label: Discover the Interoperability ecosystem
           class: btn btn-primary
-          url: '/en/api'
+          url: 'https://next.developers.italia.it/it/interoperabilita'
     - title: "I want to publish my Administration software as open source"
       text: "All the administrations are required by law to release inside
       Developers Italia the software they commissioned. The

--- a/it/come-lo-uso.md
+++ b/it/come-lo-uso.md
@@ -24,12 +24,15 @@ alternate-blocks:
           class: btn btn-white btn-outline-primary
           url: '/it/riuso'
     - title: "Voglio integrarmi con un servizio pubblico tramite API"
-      text: "Il catalogo delle API contiene la raccolta dei servizi pubblici accessibili mediante interoperabilità, con la relativa documentazione e le descrizioni OpenAPI, per permetterti di costruire servizi pubblici digitali moderni."
+      text: |
+        Nelle pagine dedicate a Interoperabilità e Piattaforma Digitale Nazionale Dati (PDND)
+        troverai tutte le informazioni, le risorse e i canali disponibili su come integrare i
+        servizi delle pubbliche amministrazioni tramite API.
       image: /assets/images/come-lo-uso-3.svg
       buttons:
-        - label: "Scopri le API pubbliche"
+        - label: Scopri l’ecosistema Interoperabilità
           class: btn btn-primary
-          url: '/it/api'
+          url: 'https://next.developers.italia.it/it/interoperabilita'
     - title: "Voglio pubblicare il software della mia Amministrazione in open source"
       text: "Tutte le amministrazioni hanno l'obbligo per legge di pubblicare in Developers Italia il software da loro commissionato. Le [Linee Guida](/it/riuso/pubblicazione) spiegano dettagliatamente il processo ed includono degli allegati tecnici che le amministrazioni possono includere nei contratti con i propri fornitori al fine di accertarsi di adempiere all'obbligo in modo corretto e di seguire le best practice dell'open source."
       image: /assets/images/come-lo-uso-4.svg

--- a/it/come-partecipo.md
+++ b/it/come-partecipo.md
@@ -35,7 +35,6 @@ alternate-blocks:
         - label: Esplora il catalogo
           class: btn btn-primary
           url: '/it/software'
-pair-blocks:
     - title: Aggiungi software pubblico al catalogo
       text: |
         Aiutaci a popolare il [catalogo](/it/software) scoprendo software

--- a/it/come-partecipo.md
+++ b/it/come-partecipo.md
@@ -48,17 +48,4 @@ pair-blocks:
         - label: Scopri di più
           class: btn btn-primary
           url: '/it/riuso/pubblicazione'
-    - title: Segnala nuove API disponibili
-      text: |
-        Molti servizi pubblici espongono interfacce di interoperabilità.
-        Il [catalogo API](/it/api) di Developers Italia ha l'obiettivo di censirle
-        tutte ed offrirle agli sviluppatori che vogliano immaginare nuovi
-        servizi integrati.
-        Se sei a conoscenza di API non ancora censite, o la stai creando tu stesso,
-        inviaci una segnalazione!
-      image: /assets/images/come-partecipo-2.svg
-      buttons:
-        - label: Segnala un'API
-          class: btn btn-primary
-          url: '/it/contatti'
 ---


### PR DESCRIPTION
Remove API section as it will be replaced by the public API catalog from PDND.

Update the content in How to use.