### PR TITLE
Add spid-php and spid-cie-oidc-php as SDK and Proxy into SPID and CIE Resources

### DIFF
--- a/_platforms/en/cie.md
+++ b/_platforms/en/cie.md
@@ -78,6 +78,24 @@ resources:
       icon: github
       url: https://github.com/italia/cie-nis-java-sdk
       desc: Java library for reading the unique card number (NIS)
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML based on SDK for PHP spid-php
+  - SDK OIDC:
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC based on SDK for PHP spid-cie-oidc-php
+  - Proxy:
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML based on SDK for PHP spid-php
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC based on SDK for PHP spid-cie-oidc-php
 ---
 
 ## Intro

--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -163,6 +163,14 @@ resources:
       url: https://github.com/italia/spid-sp-sapspid
       icon: github
       desc: SPID compatible Identity Access Management application developed in Python
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML based on SDK for PHP spid-php
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC based on SDK for PHP spid-cie-oidc-php
   - Graphic resources:
     - title: "'Enter with SPID' button"
       icon: github

--- a/_platforms/it/cie.md
+++ b/_platforms/it/cie.md
@@ -102,6 +102,24 @@ resources:
       icon: github
       url: https://github.com/italia/cieid-ios-sdk
       desc: Utilizzando questo kit gli sviluppatori di applicazioni terze iOS possono integrare nella propria app l'autenticazione mediante la cartà d'identità elettronica (CIE 3.0).
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML basato su SDK per PHP spid-php
+  - SDK OIDC:
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC basato su SDK per PHP spid-cie-oidc-php
+  - Proxy:
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML basato su SDK per PHP spid-php
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC basato su SDK per PHP spid-cie-oidc-php
 ---
 
 ## Intro

--- a/_platforms/it/spid.md
+++ b/_platforms/it/spid.md
@@ -163,6 +163,14 @@ resources:
       url: https://github.com/italia/spid-sp-sapspid
       icon: github
       desc: Applicativo di Identity Access Management compatibile con SPID sviluppato in Python
+    - title: spid-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-php
+      desc: Proxy SPID/CIE SAML basato su SDK per PHP spid-php
+    - title: spid-cie-oidc-php Proxy
+      icon: github
+      url: https://github.com/italia/spid-cie-oidc-php
+      desc: Proxy SPID/CIE OIDC basato su SDK per PHP spid-cie-oidc-php
   - Risorse grafiche:
     - title: Bottone "Entra con SPID"
       icon: github


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
This PR tackles:

* add spid-php as SDK for CIE
* add spid-php as Proxy for SPID and CIE
* add spid-cie-oidc-php as SDK OIDC for CIE
* add spid-cie-oidc-php as Proxy for SPID and CIE

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [X] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/master/CONTRIBUTING.md)
* [X] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Ready for review! :rocket:
