### PR TITLE
fix: swagger-ui rendering of model schemas

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -26,6 +26,8 @@ $pswp__assets-path: "~photoswipe/src/css/default-skin/";
 
 @import "highlight";
 
+@import './swagger-ui-overrides';
+
 a {
     text-decoration: none
 }

--- a/assets/scss/swagger-ui-overrides.scss
+++ b/assets/scss/swagger-ui-overrides.scss
@@ -1,0 +1,7 @@
+.swagger-ui .model-box {
+  width: 100%
+}
+
+.swagger-ui table.model tr.property-row.required td:first-child  {
+  min-width: 15em;
+}


### PR DESCRIPTION
Locally override the CSS and have wider schemas in the example section

Fix #1305.