### PR TITLE
chore: adapt for publiccode-crawler v4.0.0

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: publiccode-crawler crawl
         env:
-          CRAWLER_DATADIR: /tmp/data
           API_BASEURL: "https://api.developers.italia.it/v1"
           API_BEARER_TOKEN: ${{ secrets.API_BEARER_TOKEN }}
 


### PR DESCRIPTION
`CRAWLER_DATADIR` is now `DATADIR`, but it has a sane default anyway, so we can skip it.