### PR TITLE
fix: handle IETF BCP 47 language variants in publiccode descriptions

### DIFF
--- a/assets/js/services/searchEngine.js
+++ b/assets/js/services/searchEngine.js
@@ -35,7 +35,7 @@ function getDescriptionField(source, currentLang) {
 
   // 2. Look for variants (e.g. it-IT when currentLang is 'it')
   const baseLang = currentLang.split('-')[0];
-  const variants = descKeys.filter(key => key.startsWith(baseLang + '-'));
+  const variants = descKeys.filter((key) => key.startsWith(baseLang + '-'));
 
   if (variants.length > 0) {
     return descriptions[variants[0]];
@@ -121,9 +121,7 @@ const softwareItem = (source) => {
   const descriptionField = getDescriptionField(source, lang);
 
   // Handle case where no description is available
-  const description = descriptionField?.shortDescription
-    ? cropString(descriptionField.shortDescription)
-    : '';
+  const description = descriptionField?.shortDescription ? cropString(descriptionField.shortDescription) : '';
 
   const name = descriptionField?.localisedName ?? source.publiccode.name;
 

--- a/assets/js/services/searchEngine.js
+++ b/assets/js/services/searchEngine.js
@@ -125,7 +125,15 @@ const softwareItem = (source) => {
 
   const name = descriptionField?.localisedName ?? source.publiccode.name;
 
-  const category = getSoftwareCategory(source.publiccode.it.riuso?.codiceIPA);
+  // Create a default empty object for 'it' if it doesn't exist
+  // This ensures source.publiccode.it will never be undefined
+  if (source.publiccode && !source.publiccode.it) {
+    source.publiccode.it = {};
+  }
+
+  // Handle safely accessing nested properties that might not exist
+  const ipaCode = source.publiccode?.it?.riuso?.codiceIPA;
+  const category = getSoftwareCategory(ipaCode);
   const icon = category === SOFTWARE_REUSE ? 'it-software' : 'it-open-source';
 
   const fallback =

--- a/assets/js/services/searchEngine.test.js
+++ b/assets/js/services/searchEngine.test.js
@@ -8,6 +8,11 @@ jest.mock('../utils/l10n.js');
 const SHORT_DESC_IT = 'Descrizione breve in italiano';
 const SHORT_DESC_IT_VARIANT = 'Descrizione breve in italiano (IT)';
 const SHORT_DESC_EN = 'Short description in English';
+const SHORT_DESC_FR = 'Description courte en français';
+const NAME_IT = 'Nome Localizzato';
+const NAME_FR = 'Nom Localisé';
+const NAME_EN = 'Localized Name';
+const TEST_SOFTWARE = 'Test Software';
 
 // Helper function to create mock API response
 const createMockApiResponse = (source) => {
@@ -137,11 +142,11 @@ describe('searchEngine language handling', () => {
   it('handles standard language code (it)', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         description: {
           it: {
             shortDescription: SHORT_DESC_IT,
-            localisedName: 'Nome Localizzato',
+            localisedName: NAME_IT,
           },
         },
       },
@@ -153,11 +158,11 @@ describe('searchEngine language handling', () => {
   it('handles language variants (it-IT)', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         description: {
           'it-IT': {
             shortDescription: SHORT_DESC_IT_VARIANT,
-            localisedName: 'Nome Localizzato',
+            localisedName: NAME_IT,
           },
         },
       },
@@ -169,15 +174,15 @@ describe('searchEngine language handling', () => {
   it('falls back to English when current language is not available', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         description: {
           en: {
             shortDescription: SHORT_DESC_EN,
-            localisedName: 'Localized Name',
+            localisedName: NAME_EN,
           },
           fr: {
-            shortDescription: 'Description courte en français',
-            localisedName: 'Nom Localisé',
+            shortDescription: SHORT_DESC_FR,
+            localisedName: NAME_FR,
           },
         },
       },
@@ -189,23 +194,23 @@ describe('searchEngine language handling', () => {
   it('uses any available language when no preferred languages are available', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         description: {
           fr: {
-            shortDescription: 'Description courte en français',
-            localisedName: 'Nom Localisé',
+            shortDescription: SHORT_DESC_FR,
+            localisedName: NAME_FR,
           },
         },
       },
     };
 
-    await testLanguageHandling(source, 'Description courte en français');
+    await testLanguageHandling(source, SHORT_DESC_FR);
   });
 
   it('handles missing description gracefully', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         // No description field
       },
     };
@@ -216,7 +221,7 @@ describe('searchEngine language handling', () => {
   it('handles empty description object gracefully', async () => {
     const source = {
       publiccode: {
-        name: 'Test Software',
+        name: TEST_SOFTWARE,
         description: {},
       },
     };

--- a/assets/js/services/searchEngine.test.js
+++ b/assets/js/services/searchEngine.test.js
@@ -108,11 +108,11 @@ describe('searchEngine', () => {
             _source: {
               type: 'software',
               slug: 'test-slug',
-              publiccode: source.publiccode
-            }
-          }
+              publiccode: source.publiccode,
+            },
+          },
         ],
-        1
+        1,
       ]);
 
       const [items] = await search(SOFTWARE_OPEN);
@@ -128,10 +128,10 @@ describe('searchEngine', () => {
           description: {
             it: {
               shortDescription: 'Descrizione breve in italiano',
-              localisedName: 'Nome Localizzato'
-            }
-          }
-        }
+              localisedName: 'Nome Localizzato',
+            },
+          },
+        },
       };
 
       await testGetDescriptionField(source, 'Descrizione breve in italiano');
@@ -144,10 +144,10 @@ describe('searchEngine', () => {
           description: {
             'it-IT': {
               shortDescription: 'Descrizione breve in italiano (IT)',
-              localisedName: 'Nome Localizzato'
-            }
-          }
-        }
+              localisedName: 'Nome Localizzato',
+            },
+          },
+        },
       };
 
       await testGetDescriptionField(source, 'Descrizione breve in italiano (IT)');
@@ -160,14 +160,14 @@ describe('searchEngine', () => {
           description: {
             en: {
               shortDescription: 'Short description in English',
-              localisedName: 'Localized Name'
+              localisedName: 'Localized Name',
             },
             fr: {
               shortDescription: 'Description courte en français',
-              localisedName: 'Nom Localisé'
-            }
-          }
-        }
+              localisedName: 'Nom Localisé',
+            },
+          },
+        },
       };
 
       await testGetDescriptionField(source, 'Short description in English');
@@ -180,10 +180,10 @@ describe('searchEngine', () => {
           description: {
             fr: {
               shortDescription: 'Description courte en français',
-              localisedName: 'Nom Localisé'
-            }
-          }
-        }
+              localisedName: 'Nom Localisé',
+            },
+          },
+        },
       };
 
       await testGetDescriptionField(source, 'Description courte en français');
@@ -194,7 +194,7 @@ describe('searchEngine', () => {
         publiccode: {
           name: 'Test Software',
           // No description field
-        }
+        },
       };
 
       await testGetDescriptionField(source, '');
@@ -204,8 +204,8 @@ describe('searchEngine', () => {
       const source = {
         publiccode: {
           name: 'Test Software',
-          description: {}
-        }
+          description: {},
+        },
       };
 
       await testGetDescriptionField(source, '');


### PR DESCRIPTION
# Handle IETF BCP 47 language variants in publiccode descriptions

## Problem

The catalog currently crashes with an error `Cannot read properties of undefined (reading 'shortDescription')` when displaying software that uses country-specific language tags in their `publiccode.yml` files.

This happens because the code only looks for exact language matches (e.g., 'it') and doesn't recognize extended language tags like 'it-IT', even though these are valid according to the IETF BCP 47 standard and explicitly permitted in the publiccode.yml spec.

![image](https://github.com/user-attachments/assets/d26230ea-71f5-4356-9949-cdb0f90f98e5)


## Solution

I've implemented a more robust language selection algorithm that:

1. First tries an exact match with the current language
2. Then looks for variants of the same base language (e.g., 'it-IT' when the base is 'it')
3. Falls back to standard languages (first 'en', then 'it')
4. As a last resort, uses any available language description

This ensures the catalog can correctly display all software regardless of the language format used in the publiccode.yml file.

## Language Selection Logic

```mermaid
flowchart TD
    A[Start] --> B{Does exact lang match exist?}
    B -->|Yes| C[Use exact match]
    B -->|No| D{Look for variants \n e.g. 'it-IT' for 'it'}
    D -->|Found| E[Use variant]
    D -->|Not found| F{Is 'en' available?}
    F -->|Yes| G[Use 'en']
    F -->|No| H{Is 'it' available?}
    H -->|Yes| I[Use 'it']
    H -->|No| J{Any descriptions available?}
    J -->|Yes| K[Use first available]
    J -->|No| L[Return null]
    C --> M[End]
    E --> M
    G --> M
    I --> M
    K --> M
    L --> M
```

## Changes

- Added `getDescriptionField` helper function in `searchEngine.js` to implement the language selection logic
- Updated `softwareItem` to use this function and handle missing descriptions gracefully
- Added comprehensive tests for the language handling functionality
- Made `cropString` more robust to handle edge cases

## Testing

- All existing tests pass
- Added new tests specifically for language handling:
  - Standard language tags (e.g., 'it')
  - Extended language tags (e.g., 'it-IT')
  - Fallback to 'en' when current language not available
  - Fallback to any language when preferred languages not available
  - Handling of missing or empty descriptions

## Compliance

This change ensures the catalog is fully compliant with the publiccode.yml specification, which states:

> Note: since all the strings contained in this section are user-visible and written in a specific language, you must specify the language you are editing the text in (using the IETF BCP 47 specifications) by creating a sub-section with that name.

The IETF BCP 47 standard explicitly allows for country-specific language tags like 'it-IT'.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [x] I followed the indications in [[CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/main/CONTRIBUTING.md)](https://github.com/italia/developers.italia.it/blob/main/CONTRIBUTING.md)
* [x] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Ready for review! :rocket:

## Fixes
(this issue)