### PR TITLE
Added english translation of the Covid19 certificate page and minor translation corrections

### DIFF
--- a/_platforms/en/cie.md
+++ b/_platforms/en/cie.md
@@ -22,7 +22,7 @@ managers:
     - name: Istituto Poligrafico e Zecca dello Stato
       url: https://www.ipzs.it/
 resources:
-  - Documentazione:
+  - Documentation:
     - title: Technical information about the card
       icon: link
       url: https://www.cartaidentita.interno.gov.it/la-carta/caratteristiche-del-documento/

--- a/_platforms/en/dcc.md
+++ b/_platforms/en/dcc.md
@@ -1,0 +1,157 @@
+---
+title: DCC
+subtitle: COVID-19 Green certificate
+logo: /assets/images/logo-eu@2x.png
+external_website: https://www.dgc.gov.it
+payoff: EU digital COVID certificate
+description: >
+  A digital and printable certificate, issued by the Italian Health Ministry, which contains a QR Code to verify its authenticity and validity.
+lang: en
+order: 2
+highlight: true
+comingsoon: false
+abilitante: false
+layout: platform
+hide_activities: true
+owners:
+    - name: Ministero della Salute
+      url: https://www.salute.gov.it/
+resources:
+  - VerificaC19 App:
+    - title: VerificaC19 App for Android
+      icon: github
+      url: https://github.com/ministero-salute/it-dgc-verificaC19-android
+      desc: Source code of the VerificaC19 app for Android
+    - title: VerificaC19 App for iOS
+      icon: github
+      url: https://github.com/ministero-salute/it-dgc-verificaC19-ios
+      desc: Source code of the VerificaC19 app for iOS
+  - SDK:
+    - title: SDK for Kotlin (Android)
+      icon: github
+      url: https://github.com/ministero-salute/it-dgc-verificac19-sdk-android
+      desc: Digital Covid Certificate SDK Kotlin for Android (Kotlin) on which the VerificaC19 app is based
+    - title: SDK for iOS
+      icon: github
+      url: https://github.com/hrzucchetti/zconnect-verificaC19-sdk-ios
+      desc: ZConnectVerificaC19 SDK for native iOS (Swift)
+    - title: SDK for .NET / .NET Framework
+      icon: github
+      url: https://github.com/DevTrevi/DgcReader
+      desc: DgcReader SDK for .NET / .NET Framework
+    - title: SDK for Node.js
+      icon: github
+      url: https://github.com/italia/verificac19-sdk
+      desc: VerificaC19 SDK for Node.js (Javascript)
+    - title: SDK for PHP
+      icon: github
+      url: https://github.com/herald-si/verificac19-sdk-php
+      desc: Digital Covid Certificate SDK for PHP
+    - title: SDK for C++
+      icon: github
+      url: https://github.com/solari-sviluppo-prodotti/sol-verificaC19-sdk-cpp-linux
+      desc: Solari Digital Covid Certificate SDK for C++
+    - title: SDK for Java Spring
+      icon: github
+      url: https://github.com/solari-sviluppo-prodotti/sol-verificaC19-sdk-cpp-linux
+      desc: Digital Covid Certificate SDK for Java Spring Digital
+  - Utility libraries for DCC:
+    - title: DCC-Utils for Node.js
+      icon: github
+      url: https://github.com/ministero-salute/dcc-utils
+      desc: Utility library to read and verify the signature of the EU COVID-19 vaccine certificate in Node.js
+    - title: DCC-Utils for Python
+      icon: github
+      url: https://github.com/italia/dcc-utils
+      desc: Utility library to read and verify the signature of the EU COVID-19 vaccine certificate in Python
+    - title: VacDec
+      icon: github
+      url: https://github.com/HQJaTu/vacdec
+      desc: Python script to decode the EU COVID-19 vaccine certificate
+    - title: DGC for Rust
+      icon: github
+      url: https://github.com/rust-italia/dgc/
+      desc: Utility library to read and verify the signature of the EU COVID-19 vaccine certificate in Rust
+  - Documentazione:
+    - title: Digital Covid Certificate - High-level description
+      url: https://github.com/ministero-salute/it-dgc-documentation
+      icon: file
+      desc: High-level documentation on the DCC system.
+    - title: Documentation on the types of DGC Checks (ScanMode)
+      url: https://github.com/ministero-salute/it-dgc-documentation/blob/master/SCANMODE.md
+      icon: file
+      desc: Detailed documentation of the various types of DCC checks.
+    - title: Documentation on the Digital Covid Certificate Revocation List (DRL)
+      url: https://github.com/ministero-salute/it-dgc-documentation/blob/master/DRL.md
+      icon: file
+      desc: Detailed documentation on the operation of the Digital Covid Certificate Revocation List (DRL).
+    - title: Onboarding SDK documentation
+      url: https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding
+      icon: file
+      desc: Documentation and rules to onboard potential SDKs.
+    - title: Detailed SDK Android documentation
+      url: https://ministero-salute.github.io/it-dgc-verificac19-sdk-android/documentation/
+      icon: file
+      desc: Detailed documentation on the VerificaC19 SDK for Android.
+  - External sources:
+    - title: README SDK Android
+      icon: github
+      url: https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/blob/develop/README.md
+      desc: Digital Covid Certificate Kotlin (Android) SDK
+    - title: EU Digital COVID Certificate (european repository)
+      icon: github
+      url: https://github.com/eu-digital-green-certificates/dgc-overview
+      desc: EU Digital COVID Certificate (european repository)
+    - title: DPCM 12 October 2021
+      icon: github
+      url: https://www.governo.it/sites/governo.it/files/DPCM_12_ottobre.pdf
+      desc: DPCM 12 October 2021
+    - title: Annex H DPCM 12 Ottobre 2021
+      icon: github
+      url: https://www.governo.it/sites/governo.it/files/Dpcm_12_ottobre_ALLEGATO_H.pdf
+      desc: Annex H DPCM 12 Ottobre 2021
+---
+
+## Intro
+
+The COVID-19 green certificate is a digital and printable certificate, issued by the Italian Health Ministry, which contains a bi-dimensional barcode (QR Code) and an electronic seal qualified to verify its authenticity and validity. The authenticity and validity of the certificate are verified in Italy thanks to the official mobile app *VerificaC19*.
+
+**The certificate is released as a result of a:**
+
+- COVID-19 vaccination (in Italy it is released after every vaccine dose);
+- negative result to a rapid antigen test in the last 48 hours or to a molecular test in the last 72 hours;
+- recovery from COVID-19 in the last six months;
+- vaccination exemption, certified and issued as a result of specific and documented clinical conditions.
+
+Data on certificates issued in Italy are available in CSV and JSON format on [GitHub](https://github.com/ministero-salute/it-dgc-opendata/).
+
+Additional info are available at [https://www.dgc.gov.it](https://www.dgc.gov.it/).
+
+## How to contribute
+
+### Platform code
+
+It is possible the find the official source code of the Android and iOS VerificaC19 app, of the official SDK, of the various backend microservices, and the data on the issued certificates and documentation directly on the [Italian Health Ministry Organization on Github](https://github.com/ministero-salute). It is possible to contribute to the code by opening an issue or a Pull Request to directly solve a problem.
+
+### Developing and proposing a new SDK
+
+To develope a new SDK based on the [official VerificaC19 SDK](https://github.com/ministero-salute/it-dgc-verificac19-sdk-android), it is necessary to:
+
+1. Check the last edits developed for the official VerificaC19 SDK on the [CHANGELOG](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/blob/main/CHANGELOG.md).
+2. Check the [official checklist](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/blob/main/CHECKLIST_SDK.md) to implement the functionalities requested in the SDK.
+3. Refer to the [documentation repository](https://github.com/ministero-salute/it-dgc-documentation) to have detailed information on the implementation of the verification flow and of the Digital Covid Certificate Revocation List (DRL).
+
+It is recommended to use the [dgc-testdata](https://github.com/eu-digital-green-certificates/dgc-testdata) repository or part of it, which contains useful testcases to check the correctness of the libraries.
+It is possible to take inspiration from one of the SDKs available in the [official SDK list](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/#lista-librerie) already following the technical specifics and the requirements implemented by the Italian Health Ministry inside the VerificaC19 government app.
+
+To propose the insertion of a new library/SDK into the list, it is necessary to follow the following steps:
+1. Go on the repository [it-dgc-verificac19-sdk-onboarding](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding).
+2. Download from the repository the document named [autoDichiarazione.odt](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/raw/main/autoDichiarazione.odt) and fill it.
+3. Send the filled and digitally-signed document to **dgsi@postacert.sanita.it**. This document *must not* be included into the repository.
+4. Publish the source code of your solution inside a repository owned by you accordingly with the requirements indicated in [this dedicated paragraph](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/#requisiti-minimi).
+5. Open a [Pull Request](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/pulls) inside the repository, check all the features requested in the body of the Pull Request and add a new line in the [list](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/#lista-librerie) inserting the required informations.
+
+At this point, a validation phase will start, during which all technical and minimal requirements will be checked.
+In case of positive outcome, the Pull Request will be approved within a few days and will appear inside the [list](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/#lista-librerie).
+In case of negative outcome, appropriate reasons will be provided by email among with eventual suggestions to adapt the library.
+Any further update to the library will be subject to evaluations which may lead to its removal from the [lista](https://github.com/ministero-salute/it-dgc-verificac19-sdk-onboarding/#lista-librerie), in case the minimum requirements are no longer met.

--- a/_platforms/en/docs-italia.md
+++ b/_platforms/en/docs-italia.md
@@ -59,7 +59,7 @@ Il codice sorgente di Docs Italia è diviso in alcuni repository a seconda del d
 - [Pandoc filters](https://github.com/italia/docs-italia-pandoc-filters){:target="_blank"}.
 - [Commands for converting documents](https://github.com/italia/docs-italia-comandi-conversione){:target="_blank"} with Pandoc (in Haskell).
 
-### Documet
+### Document
 
 - A [starter kit](https://github.com/italia/docs-italia-starter-kit){:target="_blank"} containing files for publishing new documents.
 - The [Sphinx theme](https://github.com/italia/docs-italia-theme){:target="_blank"} which is applied by default to documents.

--- a/_platforms/en/fatturapa.md
+++ b/_platforms/en/fatturapa.md
@@ -41,13 +41,13 @@ collab:
   links:
   - name: forum
     url: "https://forum.italia.it/c/fattura-pa"
-  - title: "Dialoga su Slack"
+  - title: "Slack"
     icon: it-slack
     url: https://developersitalia.slack.com/archives/CB7434RDM
 ---
 
 ## Intro
 
-E-invoicing, which was initially only for the Public Administration, became mandatory for all invoices between private companies and entities since January 1st, 2019.
+E-invoicing, which was initially meant only for the Public Administration, became mandatory for all invoices between private companies and entities since January 1st, 2019.
 
 Official documentation, including technical rules, is available in the official website of the [Italian Revenue Agency](https://www.agenziaentrate.gov.it/wps/content/nsilib/nsi/aree+tematiche/fatturazione+elettronica){:target="_blank"}.

--- a/_platforms/en/indicepa.md
+++ b/_platforms/en/indicepa.md
@@ -3,7 +3,7 @@ title: IndicePA
 subtitle: Index of the Public Administration (IPA)
 logo: /assets/images/logo-indicepa.png
 payoff: Index of addresses of public administrations and managers of public services
-description: Database of national interest pursuant to Article 57-bis paragraph 1 of the Codice dell'Amministrazione Digitale.
+description: Database of national interest pursuant to Article 57-bis paragraph 1 of the CAD (Digital Administration Code).
 lang: en
 ref:
   it: /it/indicepa
@@ -16,7 +16,7 @@ resources:
     - title: Home page
       url: https://indicepa.gov.it
       icon: file
-      desc: Index page of the platform
+      desc: Index page of the platform.
     - title: Documentation
       url: https://indicepa.gov.it/documentale/n-documentazione.php
       icon: file

--- a/_platforms/en/otello.md
+++ b/_platforms/en/otello.md
@@ -4,7 +4,7 @@ subtitle: "Online Tax Refund at Exit: Light Lane Optimization"
 logo: /assets/images/logo-otello2@2x.png
 payoff: "Online Tax Refund at Exit: Light Lane Optimization"
 description: >
-  OTELLO 2.0 digitizes the process to obtain the "customs visa" to be affixed to the invoice to be entitled to direct relief or subsequent refund of VAT on goods purchased in Italy from non-EU entities
+  OTELLO 2.0 digitizes the process to obtain the "customs visa" to be affixed to the invoice to be entitled to direct relief or subsequent refund of VAT on goods purchased in Italy from non-EU entities.
 lang: en
 ref:
   it: /it/otello
@@ -17,6 +17,10 @@ layout: platform
 ## Intro
 
 OTELLO is the platform of the [Agenzia delle Dogane e dei Monopoli](https://www.agenziadoganemonopoli.gov.it/) which manages the process that allows non-EU subjects to obtain direct relief or refund of VAT on goods purchased on the Italian territory.
+
+<a href="https://youtu.be/f_W0d41Q9-Y?si=btySs2LxAiaWpdn2" title="Watch the video of Otello Tax free shopping in English on YouTube" target="_blank">
+  <img alt="Preview Otello Tax free shopping video" src="/assets/images/otello/otello_video_play.png" class="d-block mx-auto mb-2 mw-100" />
+</a>
 
 The digitization process of OTELLO began in 2015 with immediate benefits: greater efficiency and effectiveness in controls, the emergence of fraudulent phenomena, reduction of steps to obtain a customs visa.
 

--- a/_platforms/en/spid.md
+++ b/_platforms/en/spid.md
@@ -226,7 +226,7 @@ collab:
   links:
   - name: forum
     url: "https://forum.italia.it/c/spid"
-  - title: "Dialoga su Slack"
+  - title: "Slack"
     icon: it-slack
     url: https://developersitalia.slack.com/messages/C73R3UQE8
 ---
@@ -234,20 +234,20 @@ collab:
 ## Intro
 
 SPID (Public System for Digital Identity) is the solution that allows the Italian citizens to access all online services of the Public Administration with a single Digital Identity (username and password) that can be used from computers, tablets and smartphones.
-Citizens can get SPID through a series of private companies under agreements (known as *Identity Providers*); once the verification procedure is completed (which certifies the identity of the applicant), you are released a set of credentials that can be used on all the websites (called *Service Providers*).
+Citizens can get SPID through a series of private companies under agreements (known as *Identity Providers*); once the verification procedure is completed (which certifies the identity of the applicant), they are released a set of credentials that can be used on all the websites (called *Service Providers*).
 
 **Advantages for citizens:**
 
-- A single set of credentials for all public websites (and private websites too), secure and easy to remember
-- The verification process, after which the credentials are released, needs to be done only once
-- SPID is free
+- A single set of credentials for all public websites (and private websites too), secure and easy to remember.
+- The verification process, after which the credentials are released, needs to be done only once.
+- SPID is free.
 
 **Advantages for Service Providers:**
 
-- Secure and certified identification of users
-- No need to handle custom registration/verification processes, thus reduced costs
-- Qualified attributes (birth date/place, gender, e-mail, phone etc.)
-- Other attributes already populated by users (home address etc.)
+- Secure and certified identification of users.
+- No need to handle custom registration/verification processes, thus reduced costs.
+- Qualified attributes (birth date/place, gender, e-mail, phone etc.).
+- Other attributes already populated by users (home address etc.).
 
 SPID can be integrated in the websites of the Public Administration, but also on private websites. In the first case the service is free, while for privates fees are applied. There are several advantages for including SPID in private websites: banks and insurance companies, for instance, can easily recognize users who want to open an account just by accepting their SPID login, without any additional verification process.
 


### PR DESCRIPTION
## Description

<!--- Describe in details the proposed changes -->
This PR tackles:

* Added English Covid19 certificate page (previously available only in italian).
* Corrected minor translation mistakes.

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [X] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/main/CONTRIBUTING.md)
* [X] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [X] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->

Fixes #345 (partially)