### PR TITLE
fix: look for country code `IT` in publiccode data

### DIFF
--- a/_includes/home-listing-sw.html
+++ b/_includes/home-listing-sw.html
@@ -30,7 +30,7 @@
             <div class="col-md {% if withimages!=true %}px-3{%endif%}">
               {% if withimages == true %}
 
-              {% if item.publiccode.it.riuso.codiceIPA != nil %}
+              {% if item.publiccode.IT.riuso.codiceIPA != nil %}
                 {% assign category = "software_reuse" %}
                 {% assign icon = "it-software" %}
                 {% assign fallback = "/assets/images/cover_softwareriuso.png" %}

--- a/_includes/software-listing.html
+++ b/_includes/software-listing.html
@@ -9,7 +9,7 @@
   {% assign sw_name = description.localisedName | default: software.publiccode.name %}
 
   {% assign sw_url = '/' | append: active_lang | append: '/software/' | append: software.slug | downcase %}
-  {% if software.publiccode.it.riuso.codiceIPA != nil %}
+  {% if software.publiccode.IT.riuso.codiceIPA != nil %}
     {% assign category = "software_reuse" %}
     {% assign icon = "it-software" %}
     {% assign fallback = "/assets/images/cover_softwareriuso.png" %}

--- a/_layouts/brand-pa.html
+++ b/_layouts/brand-pa.html
@@ -13,7 +13,7 @@ layout: default-pa
 {% include linklist.html items=subnav dynamic=true %}
 {% endcomment %}
 
-{% assign generic_sw = site.data.crawler.software | where_exp: "item", "item.publiccode.it.riuso.codiceIPA == page.ipa" | nested_sort_natural: "publiccode.name" | slice: 0, 60 %}
+{% assign generic_sw = site.data.crawler.software | where_exp: "item", "item.publiccode.IT.riuso.codiceIPA == page.ipa" | nested_sort_natural: "publiccode.name" | slice: 0, 60 %}
 
 {% assign root = '/' | append: active_lang  %}
 

--- a/_layouts/software-details.html
+++ b/_layouts/software-details.html
@@ -83,8 +83,8 @@ layout: default
             {% if page.publiccode.legal.repoOwner %}
             <div class="col-sm">
               <p><span class="label">Gestito da</span>
-                {% if page.publiccode.it.riuso.codiceIPA %}
-                <a href="/{{ active_lang }}/pa/{{ page.publiccode.it.riuso.codiceIPA | downcase }}">
+                {% if page.publiccode.IT.riuso.codiceIPA %}
+                <a href="/{{ active_lang }}/pa/{{ page.publiccode.IT.riuso.codiceIPA | downcase }}">
                 {{ page.publiccode.legal.repoOwner }}
                 </a>
                 {% else %}
@@ -548,7 +548,7 @@ layout: default
               <div class="col-6 col-md">
                 <p>
                   <span class="label">{{ t.software.enabling_platforms }}</span>
-                  {% assign p = page.publiccode.it.piattaforme %}
+                  {% assign p = page.publiccode.IT.piattaforme %}
                   {% assign all_false = true %}
                   {% for key in p %}
                   {% if key.last == true %}
@@ -590,7 +590,7 @@ layout: default
               <div class="col-6 col-md">
                 <p>
                   <span class="label">{{ t.software.compliance }}</span>
-                  {% assign p = page.publiccode.it.conforme %}
+                  {% assign p = page.publiccode.IT.conforme %}
                   {% assign all_false = true %}
                   {% for key in p %}
                   {% if key.last == true %}
@@ -754,7 +754,7 @@ layout: default
         {% assign relsw_name = relsw_description.localisedName | default: relsw.publiccode.name %}
         {% assign relsw_url = '/' | append: active_lang | append: '/software/' | append: relsw.slug | downcase %}
 
-        {% if relsw.publiccode.it.riuso.codiceIPA != nil %}
+        {% if relsw.publiccode.IT.riuso.codiceIPA != nil %}
         {% assign category = "software_reuse" %}
         {% assign icon = "it-software" %}
         {% assign fallback = "/assets/images/cover_softwareriuso.png" %}

--- a/_layouts/software.html
+++ b/_layouts/software.html
@@ -12,7 +12,7 @@ layout: default
 {% endcomment %}
 
 {% assign recent_sw = site.data.crawler.software | sort: "publiccode.releaseDate" | reverse | slice: 0, 4 %}
-{% assign efficient_pas = site.data.crawler.software | where_exp: "item", "item.publiccode.it.riuso.codiceIPA != nil" | group_by: "publiccode.it.riuso.codiceIPA" | sort: "size" | reverse | slice: 0, 3 %}
+{% assign efficient_pas = site.data.crawler.software | where_exp: "item", "item.publiccode.IT.riuso.codiceIPA != nil" | group_by: "publiccode.IT.riuso.codiceIPA" | sort: "size" | reverse | slice: 0, 3 %}
 
 <div class="container">
   <div class="intro mt-5">

--- a/assets/js/api/elasticSearch.js
+++ b/assets/js/api/elasticSearch.js
@@ -26,15 +26,15 @@ export const querySoftware = async ({ type, searchValue, filters, sortBy, from, 
   }
 
   if (type === SOFTWARE_REUSE) {
-    must.push({ exists: { field: 'publiccode.it.riuso.codiceIPA' } });
+    must.push({ exists: { field: 'publiccode.IT.riuso.codiceIPA' } });
   }
 
   const must_not = [];
 
   if (type === SOFTWARE_OPEN) {
     must_not.push(
-      { exists: { field: 'publiccode.it.riuso.codiceIPA' } },
-      { match: { 'publiccode.indendedAudience.unsupportedCountries': 'it' } }
+      { exists: { field: 'publiccode.IT.riuso.codiceIPA' } },
+      { match: { 'publiccode.indendedAudience.unsupportedCountries': 'IT' } }
     );
   }
 

--- a/assets/js/services/searchEngine.js
+++ b/assets/js/services/searchEngine.js
@@ -126,9 +126,9 @@ const softwareItem = (source) => {
   const name = descriptionField?.localisedName ?? source.publiccode.name;
 
   // Create a default empty object for 'it' if it doesn't exist
-  // This ensures source.publiccode.it will never be undefined
-  if (source.publiccode && !source.publiccode.it) {
-    source.publiccode.it = {};
+  // This ensures source.publiccode.IT will never be undefined
+  if (source.publiccode && !source.publiccode.IT) {
+    source.publiccode.IT = {};
   }
 
   // Handle safely accessing nested properties that might not exist


### PR DESCRIPTION
Following italia/publiccode-crawler#468, the publiccode data returned by the API use the key `IT` rather than `it` for the country specific part.

## Description

<!--- Describe in details the proposed changes -->
This PR tackles:

* ...
* ...
* ...

In particular, the ...

## Checklist
<!--- Please insert and `x` when each of the following steps is done -->

* [ ] I followed the indications in [CONTRIBUTING.md](https://github.com/italia/developers.italia.it/blob/main/CONTRIBUTING.md)
* [ ] The documentation related to the proposed change has been updated accordingly (also comments in code).
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Ready for review! :rocket:

## Fixes
<!-- Please insert the issue numbers after the # symbol -->

Fixes #
