### PR TITLE
fix: OpenSearch migration fixes

### DIFF
--- a/scripts/get-publishers.js
+++ b/scripts/get-publishers.js
@@ -26,7 +26,7 @@ function toElasticSearchBulkFile(data, filename) {
     .forEach(publisher => {
       const metadata = {
         'index': {
-          '_index': 'publishers',
+          '_index': 'developers_italia_it',
           '_id': publisher.id,
         }
       }

--- a/scripts/get-software.js
+++ b/scripts/get-software.js
@@ -62,7 +62,7 @@ function toElasticSearchBulkFile(software, filename) {
     .forEach(s => {
       const metadata = {
         'index': {
-          '_index': 'software',
+          '_index': 'developers_italia_it',
           '_id': s.id,
         }
       }


### PR DESCRIPTION
## Modifiche

Correzioni per completare la migrazione a OpenSearch:

- Fix script `get-software.js` e `get-publishers.js` per scrivere su indice `developers_italia_it` (il frontend cerca su questo indice)
- Fix sintassi Liquid in `software-details.html` (usa `default` invece di `or`)
- Aggiorna `searchyll` con fix per compatibilità OpenSearch

## Test
- ✅ Preview Vercel verificata: https://developers-italia-djs6gg3uc-dip-trasformazione-digitale.vercel.app/
- ✅ Catalogo software funzionante (431 risultati)
- ✅ Ricerca e filtri operativi